### PR TITLE
feat(cli): add Windows support for Botpress CLI execution

### DIFF
--- a/bp-integration-runner/package-lock.json
+++ b/bp-integration-runner/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bp-integration-runner",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bp-integration-runner",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "ISC",
       "dependencies": {
         "@botpress/cli": "^1.7.2",

--- a/bp-integration-runner/package.json
+++ b/bp-integration-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp-integration-runner",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "bin": {
     "bp-integration-runner": "run.js"

--- a/bp-integration-runner/run.js
+++ b/bp-integration-runner/run.js
@@ -9,13 +9,31 @@ import path from "path";
 import fs from "fs";
 import boxen from "boxen";
 import { fileURLToPath } from 'url';
+import os from 'os';
 
 const __filename = fileURLToPath(import.meta.url);
-const __localbp = path.resolve(path.resolve(process.cwd()), "node_modules/.bin/bp");
+const isWindows = os.platform() === 'win32';
+const __localbp = path.join(process.cwd(), "node_modules", ".bin", isWindows ? "bp.cmd" : "bp");
 
+// Verify that bp executable exists
+if (!fs.existsSync(__localbp)) {
+  console.log(boxen(
+    `
+    Could not find Botpress CLI at ${__localbp}
+    Please ensure @botpress/cli is installed in your project
+    `,
+    {
+      title: "⚠️ Missing Botpress CLI ⚠️",
+      titleAlignment: "center",
+      borderColor: "red",
+      padding: 1,
+    }
+  ));
+  process.exit(1);
+}
 // Load the parent project's .env file
 try {
-  dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+  dotenv.config({ path: path.join(process.cwd(), ".env") });
 } catch (e) {
   console.error("⚠️ No .env file found in the parent directory ⚠️");
   process.exit(1);


### PR DESCRIPTION
Modify the CLI path resolution to handle Windows-specific executable extension (.cmd) by detecting the operating system platform. This ensures the integration runner works correctly on both Windows and Unix-based systems.

- Add OS platform detection using os.platform()
- Update bp executable path to use .cmd extension on Windows
- Maintain existing path resolution for Unix-based systems