### PR TITLE
Fixes and removing access token

### DIFF
--- a/integrations/zoho/hub.md
+++ b/integrations/zoho/hub.md
@@ -37,9 +37,9 @@ Before making any API calls using the Zoho Botpress Integration, you must regist
 7. Click **Create**, select your CRM, and click **Create** again.
 8. Download your **credentials file**.
 
-### Generate Access Token
+### Generate Refresh Token
 
-Now, execute the following **cURL** command to obtain an access token. Ensure you use the **correct region URL** for OAuth authentication.
+Now, execute the following **cURL** command to obtain a refresh token. Ensure you use the **correct region URL** for OAuth authentication.
 
 #### **Zoho Accounts Domains:**
 | Region         | Accounts URL                       |
@@ -80,12 +80,54 @@ If the request is successful, you should receive a response similar to the follo
 }
 ```
 
+# Define the Zoho OAuth token endpoint based on your region
+$uri = "https://YOUR_REGION_ACCOUNT_URL/oauth/v2/token"
+
+# Define the request body with required parameters
+$body = @{
+    grant_type    = "authorization_code"
+    client_id     = "YOUR_CLIENT_ID"
+    client_secret = "YOUR_CLIENT_SECRET"
+    redirect_uri  = "YOUR_REDIRECT_URI"
+    code          = "AUTHORIZATION_CODE"
+}
+
+### Generate Refresh Token using PowerShell (Windows Users)
+
+⚠️ Use this PowerShell command if you're on Windows. Do NOT use cURL—this is for PowerShell only! ⚠️
+
+#### Define the Zoho OAuth token endpoint based on your region
+$uri = "https://YOUR_REGION_ACCOUNT_URL/oauth/v2/token"
+
+# Define the request body with required parameters
+$body = @{
+    grant_type    = "authorization_code"
+    client_id     = "YOUR_CLIENT_ID"
+    client_secret = "YOUR_CLIENT_SECRET"
+    redirect_uri  = "YOUR_REDIRECT_URI"
+    code          = "AUTHORIZATION_CODE"
+}
+
+##### Convert body to URL-encoded form data
+```
+$body = $body | ForEach-Object { "$( $_.Key )=$( $_.Value )" } -join "&"
+```
+
+#### Send the POST request using Invoke-RestMethod
+```
+$response = Invoke-RestMethod -Uri $uri -Method Post -ContentType "application/x-www-form-urlencoded" -Body $body
+```
+
+#### Output the response
+```
+$response
+```
+
 ## Configure Zoho Botpress Integration
 Once you have the necessary credentials, navigate to the **Zoho Botpress Integration** configuration page and enter the following details:
 
 - **Client ID**
 - **Client Secret**
-- **Access Token**
 - **Refresh Token**
 - **Region**
 

--- a/integrations/zoho/integration.definition.ts
+++ b/integrations/zoho/integration.definition.ts
@@ -34,7 +34,6 @@ export default new IntegrationDefinition({
     schema: z.object({
       clientId: z.string().describe('Your Zoho Client ID'),
       clientSecret: z.string().describe('Your Zoho Client Secret'),
-      accessToken: z.string().describe('Your Zoho Access Token'),
       refreshToken: z.string().describe('Your Zoho Refresh Token'),
       dataCenter: z.enum(['us', 'eu', 'in', 'au', 'cn', 'jp', 'ca']).describe('Zoho Data Center Region'),
     }),

--- a/integrations/zoho/src/actions/create-appointment.ts
+++ b/integrations/zoho/src/actions/create-appointment.ts
@@ -6,7 +6,6 @@ export const createAppointment: Implementation['actions']['createAppointment'] =
   const validatedInput = createAppointmentInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/delete-appointment.ts
+++ b/integrations/zoho/src/actions/delete-appointment.ts
@@ -6,7 +6,6 @@ export const deleteAppointment: Implementation['actions']['deleteAppointment'] =
   const validatedInput = deleteAppointmentInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/delete-record.ts
+++ b/integrations/zoho/src/actions/delete-record.ts
@@ -6,7 +6,6 @@ export const deleteRecord: Implementation['actions']['deleteRecord'] = async ({ 
   const validatedInput = deleteRecordInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/get-appointment-by-id.ts
+++ b/integrations/zoho/src/actions/get-appointment-by-id.ts
@@ -6,7 +6,6 @@ export const getAppointmentById: Implementation['actions']['getAppointmentById']
   const validatedInput = getAppointmentByIdInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/get-appointments.ts
+++ b/integrations/zoho/src/actions/get-appointments.ts
@@ -7,7 +7,6 @@ export const getAppointments: Implementation['actions']['getAppointments'] = asy
   const params = validatedInput.params ?? "{}";
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/get-file.ts
+++ b/integrations/zoho/src/actions/get-file.ts
@@ -6,7 +6,6 @@ export const getFile: Implementation['actions']['getFile'] = async ({ ctx, clien
   const validatedInput = getFileInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/get-organization-details.ts
+++ b/integrations/zoho/src/actions/get-organization-details.ts
@@ -6,7 +6,6 @@ export const getOrganizationDetails: Implementation['actions']['getOrganizationD
   const validatedInput = emptyInputSchema.parse({});
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/get-record-by-id.ts
+++ b/integrations/zoho/src/actions/get-record-by-id.ts
@@ -6,7 +6,6 @@ export const getRecordById: Implementation['actions']['getRecordById'] = async (
   const validatedInput = getRecordByIdInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/get-records.ts
+++ b/integrations/zoho/src/actions/get-records.ts
@@ -7,7 +7,6 @@ export const getRecords: Implementation['actions']['getRecords'] = async ({ ctx,
   const params = validatedInput.params ?? "{}"; // Default to empty JSON if no params provided
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/get-users.ts
+++ b/integrations/zoho/src/actions/get-users.ts
@@ -7,7 +7,6 @@ export const getUsers: Implementation['actions']['getUsers'] = async ({ ctx, cli
   const params = validatedInput.params ?? "{}"; // Ensure params is always a valid JSON string
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/insert-record.ts
+++ b/integrations/zoho/src/actions/insert-record.ts
@@ -5,7 +5,6 @@ import type { Implementation } from '../misc/types';
 export const insertRecord: Implementation['actions']['insertRecord'] = async ({ ctx, client, logger, input }) => {
   const validatedInput = insertRecordInputSchema.parse(input);
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/make-api-call.ts
+++ b/integrations/zoho/src/actions/make-api-call.ts
@@ -6,7 +6,6 @@ export const makeApiCall: Implementation['actions']['makeApiCall'] = async ({ ct
   const validatedInput = makeApiCallInputSchema.parse(input)
   const params = validatedInput.params ?? "{}"; // Default to empty JSON if no params provided
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/search-records.ts
+++ b/integrations/zoho/src/actions/search-records.ts
@@ -6,7 +6,6 @@ export const searchRecords: Implementation['actions']['searchRecords'] = async (
   const validatedInput = searchRecordsInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/send-email.ts
+++ b/integrations/zoho/src/actions/send-email.ts
@@ -6,7 +6,6 @@ export const sendMail: Implementation['actions']['sendMail'] = async ({ ctx, cli
   const validatedInput = sendMailInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/update-appointment.ts
+++ b/integrations/zoho/src/actions/update-appointment.ts
@@ -6,7 +6,6 @@ export const updateAppointment: Implementation['actions']['updateAppointment'] =
   const validatedInput = updateAppointmentInputSchema.parse(input);
 
   const zohoClient = getClient(
-    ctx.configuration.accessToken,
     ctx.configuration.refreshToken,
     ctx.configuration.clientId,
     ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/update-record.ts
+++ b/integrations/zoho/src/actions/update-record.ts
@@ -5,7 +5,6 @@ import type { Implementation } from '../misc/types';
 export const updateRecord: Implementation['actions']['updateRecord'] = async ({ ctx, client, logger, input }) => {
     const validatedInput = updateRecordInputSchema.parse(input);
     const zohoClient = getClient(
-        ctx.configuration.accessToken,
         ctx.configuration.refreshToken,
         ctx.configuration.clientId,
         ctx.configuration.clientSecret,

--- a/integrations/zoho/src/actions/upload-file.ts
+++ b/integrations/zoho/src/actions/upload-file.ts
@@ -5,7 +5,6 @@ import type { Implementation } from "../misc/types";
 export const uploadFile: Implementation["actions"]["uploadFile"] = async ({ ctx, client, logger, input }) => {
     const validatedInput = uploadFileInputSchema.parse(input);
     const zohoClient = getClient(
-        ctx.configuration.accessToken,
         ctx.configuration.refreshToken,
         ctx.configuration.clientId,
         ctx.configuration.clientSecret,

--- a/integrations/zoho/src/setup/register.ts
+++ b/integrations/zoho/src/setup/register.ts
@@ -5,7 +5,6 @@ import type { RegisterFunction } from '../misc/types';
 export const register: RegisterFunction = async ({ ctx, client, logger }) => {
   try {
     const zohoClient = getClient(
-      ctx.configuration.accessToken,
       ctx.configuration.refreshToken,
       ctx.configuration.clientId,
       ctx.configuration.clientSecret,
@@ -14,14 +13,7 @@ export const register: RegisterFunction = async ({ ctx, client, logger }) => {
       client
     );
 
-    await client.setState({
-      id: ctx.integrationId,
-      type: "integration",
-      name: 'credentials',
-      payload: {
-        accessToken: ctx.configuration.accessToken,
-      }
-    });
+    await zohoClient.refreshAccessToken()
 
     const orgResult = await zohoClient.getOrganizationDetails();
 


### PR DESCRIPTION
Fixes based off of an email received from Kieran where a US based client was having issues configuring the Zoho CRM integration (non-hitl). 

- Added to readme instructions for powershell generating a refresh token
- Added data centers map for the Zoho API calls, previously used "us" instead of "com" within the base api endpoint
- Removed access token entirely, only using a refresh token and refreshing when access token is expired (similar changes to https://github.com/botpress/growth/pull/37/commits/367c47e03e833a17842cdbe0ab22650c0aad72a6)

@matthewbotpress @ptrckbp @envyrovasileski 