### PR TITLE
feat(hitl-salesforce): add file sharing upload support

### DIFF
--- a/integrations/hitl-salesforce/integration.definition.ts
+++ b/integrations/hitl-salesforce/integration.definition.ts
@@ -14,7 +14,7 @@ export const user = {
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'SalesForce Messaging (Alpha)',
-  version: '0.3.0',
+  version: '0.3.1',
   icon: 'icon.svg',
   description:
     'This integration allows your bot to interact with Salesforce Messaging, this version uses the HITL Interface',

--- a/integrations/hitl-salesforce/integration.definition.ts
+++ b/integrations/hitl-salesforce/integration.definition.ts
@@ -14,7 +14,7 @@ export const user = {
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'SalesForce Messaging (Alpha)',
-  version: '0.2.0',
+  version: '0.3.0',
   icon: 'icon.svg',
   description:
     'This integration allows your bot to interact with Salesforce Messaging, this version uses the HITL Interface',

--- a/integrations/hitl-salesforce/package.json
+++ b/integrations/hitl-salesforce/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-jsdoc": "^39.6.4",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-unused-imports": "^2.0.0",
+    "form-data": "^4.0.2",
     "lodash": "^4.17.21",
     "prettier": "2.8.1",
     "uuid": "^11.0.3",

--- a/integrations/hitl-salesforce/package.json
+++ b/integrations/hitl-salesforce/package.json
@@ -4,7 +4,7 @@
   "description": "Integration for HITL Salesforce Messaging",
   "private": true,
   "scripts": {
-    "add-interface": "pnpm bp add  interface:hitl@1.0.0 --y",
+    "add-interface": "pnpm bp add  interface:hitl@1.1.0 --y",
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",

--- a/integrations/hitl-salesforce/pnpm-lock.yaml
+++ b/integrations/hitl-salesforce/pnpm-lock.yaml
@@ -34,6 +34,9 @@ dependencies:
   eslint-plugin-unused-imports:
     specifier: ^2.0.0
     version: 2.0.0(@typescript-eslint/eslint-plugin@5.47.0)(eslint@8.57.1)
+  form-data:
+    specifier: ^4.0.2
+    version: 4.0.2
   lodash:
     specifier: ^4.17.21
     version: 4.17.21
@@ -1353,7 +1356,7 @@ packages:
     resolution: {integrity: sha512-9pU/8mmjSSOb4CXVsvGIevN+MlO/t9OWtKadTaLuN85Gge3HGorUckgp8A/2FH4V4hJ7JuQ3LIeI7KAV9ITZrQ==}
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.1
+      form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -1363,7 +1366,7 @@ packages:
     resolution: {integrity: sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==}
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.1
+      form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -1453,6 +1456,13 @@ packages:
       normalize-url: 4.5.1
       responselike: 1.0.2
     dev: true
+
+  /call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   /call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
@@ -1713,6 +1723,14 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   /duplexer3@0.1.5:
     resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
     dev: true
@@ -1808,6 +1826,10 @@ packages:
     dependencies:
       get-intrinsic: 1.2.4
 
+  /es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
@@ -1818,11 +1840,26 @@ packages:
     dependencies:
       es-errors: 1.3.0
 
+  /es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+
   /es-set-tostringtag@2.0.3:
     resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.4
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  /es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
@@ -2325,12 +2362,13 @@ packages:
     dependencies:
       is-callable: 1.2.7
 
-  /form-data@4.0.1:
-    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
+  /form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
   /fs.realpath@1.0.0:
@@ -2373,6 +2411,28 @@ packages:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
+
+  /get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  /get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   /get-stream@4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
@@ -2454,6 +2514,10 @@ packages:
     dependencies:
       get-intrinsic: 1.2.4
 
+  /gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   /got@9.6.0:
     resolution: {integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==}
     engines: {node: '>=8.6'}
@@ -2507,6 +2571,10 @@ packages:
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+
+  /has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
   /has-tostringtag@1.0.2:
@@ -2924,6 +2992,10 @@ packages:
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
+
+  /math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}

--- a/integrations/hitl-salesforce/src/channels.ts
+++ b/integrations/hitl-salesforce/src/channels.ts
@@ -89,7 +89,7 @@ export const channels = {
       image: async (props: bp.MessageProps['hitl']['image']) => {
         const { payload } = props
         const salesforceClient = await getSalesforceClientFromMessage(props)
-        await salesforceClient.sendMessage(payload.imageUrl)
+        await salesforceClient.sendFile({ fileUrl: payload.imageUrl })
       },
       video: async (props: bp.MessageProps['hitl']['video']) => {
         const { payload } = props
@@ -97,11 +97,10 @@ export const channels = {
         await salesforceClient.sendMessage(payload.videoUrl)
       },
       file: async (props: bp.MessageProps['hitl']['file']) => {
-        console.log('Will send file', { payload: props.payload })
-        const { payload } = props
+        const { payload: { title, fileUrl } } = props
         const salesforceClient = await getSalesforceClientFromMessage(props)
-        await salesforceClient.sendMessage(payload.fileUrl)
-      },
+        await salesforceClient.sendFile({ fileUrl, title })
+      }
     },
   },
 } satisfies bp.IntegrationProps['channels']

--- a/integrations/hitl-salesforce/src/channels.ts
+++ b/integrations/hitl-salesforce/src/channels.ts
@@ -100,6 +100,45 @@ export const channels = {
         const { payload: { title, fileUrl } } = props
         const salesforceClient = await getSalesforceClientFromMessage(props)
         await salesforceClient.sendFile({ fileUrl, title })
+      },
+      bloc: async (props: bp.MessageProps['hitl']['bloc']) => {
+        const salesforceClient = await getSalesforceClientFromMessage(props)
+        for (const item of props.payload.items) {
+          switch (item.type) {
+            case 'text':
+              await salesforceClient.sendMessage(item.payload.text)
+              break
+            case 'markdown':
+              await salesforceClient.sendMessage(item.payload.markdown)
+              break
+            case 'image':
+              await salesforceClient.sendFile({ fileUrl: item.payload.imageUrl })
+              break
+            case 'video':
+              await salesforceClient.sendMessage(item.payload.videoUrl)
+              break
+            case 'audio':
+              await salesforceClient.sendMessage(item.payload.audioUrl)
+              break
+            case 'file':
+              const { title: fileTitle, fileUrl } = item.payload
+              await salesforceClient.sendFile({ fileUrl, title: fileTitle })
+              break
+            case 'location':
+              const { title, address, latitude, longitude } = item.payload
+              const messageParts = []
+
+              if (title) {
+                messageParts.push(title, '')
+              }
+              if (address) {
+                messageParts.push(address, '')
+              }
+              messageParts.push(`Latitude: ${latitude}`, `Longitude: ${longitude}`)
+              await salesforceClient.sendMessage(messageParts.join('\n'))
+              break
+          }
+        }
       }
     },
   },

--- a/integrations/hitl-salesforce/src/utils.ts
+++ b/integrations/hitl-salesforce/src/utils.ts
@@ -16,3 +16,8 @@ export const forceCloseConversation = async (ctx: bp.AnyMessageProps['ctx'], con
     // We need to keep the process running for a little bit more, otherwise the lambda will not do the call above
     await new Promise(resolve => setTimeout(resolve, 1000))
 }
+
+export const getFileExtensionFromUrl = (fileUrl: string): string => {
+    const url = new URL(fileUrl.trim())
+    return url.pathname.includes('.') ? (url.pathname.split('.').pop()?.toLowerCase() ?? '') : ''
+}


### PR DESCRIPTION
This PR adds support for file upload, so instead of sending a link HITL will actually upload the file to Salesforce, allowing better visualization by the agent.

https://developer.salesforce.com/docs/service/messaging-api/references/miaw-api-reference?meta=sendFile

We will fallback to the message link if the file type is not supported or too large

![image](https://github.com/user-attachments/assets/f32c4cda-e8e7-41a1-963b-ce2ffa60debd)
