### PR TITLE
fix(bp-integration-runner): name matching

### DIFF
--- a/bp-integration-runner/run.js
+++ b/bp-integration-runner/run.js
@@ -108,7 +108,7 @@ const getIntegrationId = async (integrationName) => {
   const integrataions = response.data.integrations;
 
   const integration = integrataions.find((integration) => {
-    return integration.name.split("/")[1] === integrationName;
+    return integration.name === integrationName;
   });
 
   if (!integration) {


### PR DESCRIPTION
workspace handle is always included in package.json or else integration deployment doesn't even work. Might as well just keep the name solely.


Resolves https://github.com/botpress/growth/issues/32