### PR TITLE
Add hubspot-help-desk-hitl fix

### DIFF
--- a/integrations/hubspot-help-desk-hitl/integration.definition.ts
+++ b/integrations/hubspot-help-desk-hitl/integration.definition.ts
@@ -7,7 +7,7 @@ import { events, configuration, states, channels, user } from './src/definitions
 export default new IntegrationDefinition({
   name: integrationName,
   title: 'HubSpot Help Desk HITL',
-  version: '1.0.2',
+  version: '1.0.3',
   icon: 'icon.svg',
   description: 'This integration allows your bot to use HubSpot as a HITL provider. Messages will appear in HubSpot Help Desk.',
   readme: 'hub.md',

--- a/integrations/hubspot-help-desk-hitl/src/channels.ts
+++ b/integrations/hubspot-help-desk-hitl/src/channels.ts
@@ -15,11 +15,17 @@ export const channels = {
           logger.forBot().error('No HubSpot Conversation Id')
           return
         }
+        
+        const { user: botpressUser } = await client.getOrCreateUser({
+          tags: {
+            hubspotConversationId: hubspotConversationId,
+          },
+        })
 
         const userInfoState = await client.getState({
-          id: ctx.integrationId,
+          id: botpressUser.id,
           name: "userInfo",
-          type: "integration",
+          type: "user",
         });
     
         // Check if either phoneNumber or email is present in the userInfo state
@@ -47,8 +53,7 @@ export const channels = {
         }
         
         return await hubSpotClient.sendMessage(
-          userMessage, name, contactIdentifier
-        )
+          userMessage, name, contactIdentifier, botpressUser.tags.integrationThreadId as string)
       },
     },
   },

--- a/integrations/hubspot-help-desk-hitl/src/client.ts
+++ b/integrations/hubspot-help-desk-hitl/src/client.ts
@@ -356,7 +356,7 @@ export class HubSpotApi {
     const deliveryType = isEmail ? "HS_EMAIL_ADDRESS" : "HS_PHONE_NUMBER";
 
     const payload = {
-      text: `Name: ${name} \nTitle: ${title} \nDescription: ${description}`,
+      text: `Title: ${title} \nDescription: ${description}`,
       messageDirection: "INCOMING",
       integrationThreadId: integrationThreadId,
       channelAccountId: channelAccountId,
@@ -388,14 +388,14 @@ export class HubSpotApi {
    * @param {string} contactIdentifier - Sender's phone number or email address.
    * @returns {Promise<any>} The message response.
    */
-  public async sendMessage(message: string, senderName: string, contactIdentifier: string): Promise<any> {
+  public async sendMessage(message: string, senderName: string, contactIdentifier: string, integrationThreadId: string): Promise<any> {
     const { state } = await this.bpClient.getState({
       id: this.ctx.integrationId,
       name: "channelInfo",
       type: "integration",
     });
 
-    if (!state?.payload?.channelId || !state?.payload?.channelAccountId || !state?.payload?.integrationThreadId) {
+    if (!state?.payload?.channelId || !state?.payload?.channelAccountId) {
       return {
         success: false,
         message: "Missing channel info",
@@ -404,7 +404,7 @@ export class HubSpotApi {
       };
     }
 
-    const { channelId, channelAccountId, integrationThreadId } = state.payload;
+    const { channelId, channelAccountId } = state.payload;
 
     const endpoint = `${hubspot_api_base_url}/conversations/v3/custom-channels/${channelId}/messages`;
 

--- a/integrations/hubspot-help-desk-hitl/src/definitions/index.ts
+++ b/integrations/hubspot-help-desk-hitl/src/definitions/index.ts
@@ -17,7 +17,7 @@ export const states = {
     }),
   },
   userInfo: {
-    type: "integration",
+    type: "user",
     schema: z.object({
       phoneNumber: z.string().optional(),
       name: z.string(),
@@ -29,15 +29,17 @@ export const states = {
     schema: z.object({
       channelId: z.string(),
       channelAccountId: z.string(),
-      integrationThreadId: z.string(),
     })
   }
 } satisfies IntegrationDefinitionProps['states']
 
 export const user = {
   tags: {
-    id: { description: 'Hubspot User Id', title: 'Hubspot User Id' },
     email: { description: 'User Email', title: 'User Email' },
-    phone: { description: 'User Phone Number', title: 'User Phone Number' }
+    phoneNumber: { description: 'Hubspot Phone Number', title: 'Hubspot Phone Number' },
+    agentId: { description: 'Hubspot Agent Id', title: 'Hubspot Agent Id' },
+    integrationThreadId: { description: 'Hubspot Integration Thread Id', title: 'Hubspot Integration Thread Id' },
+    hubspotConversationId: { description: 'Hubspot Conversation Id', title: 'Hubspot Conversation Id' },
+    contactType: { description: 'Contact Type (email or phone)', title: 'Contact Type' },
   },
 } satisfies IntegrationDefinitionProps['user']

--- a/integrations/hubspot-help-desk-hitl/src/events/operatorSendMessage.ts
+++ b/integrations/hubspot-help-desk-hitl/src/events/operatorSendMessage.ts
@@ -17,7 +17,7 @@ export const handleOperatorReplied = async ({
 
   const { user } = await client.getOrCreateUser({
     tags: {
-      id: hubspotEvent.message?.senders?.[0]?.actorId,
+      agentId: hubspotEvent.message?.senders?.[0]?.actorId,    
     },
   })
 

--- a/integrations/hubspot-help-desk-hitl/src/setup/register.ts
+++ b/integrations/hubspot-help-desk-hitl/src/setup/register.ts
@@ -3,7 +3,7 @@ import * as bpclient from "@botpress/client";
 import type { RegisterFunction } from '../misc/types';
 
 export const register: RegisterFunction = async ({ ctx, client, logger }) => {
-  logger.info("Registering configuration...");
+  logger.forBot().info("Registering configuration...");
   
   try {
     const hubspotClient = getClient(
@@ -24,7 +24,7 @@ export const register: RegisterFunction = async ({ ctx, client, logger }) => {
       ctx.configuration.appId
     );
 
-    logger.info(`Created custom channel with ID: ${newChannelId}`);
+    logger.forBot().info(`Created custom channel with ID: ${newChannelId}`);
 
     // Retry loop with exponential backoff (up to 1 minute)
     let alreadyConnected = false;
@@ -39,25 +39,25 @@ export const register: RegisterFunction = async ({ ctx, client, logger }) => {
       );
 
       if (alreadyConnected) {
-        logger.info(`Channel ID ${newChannelId} found in channel list after ${attempt + 1} attempt(s).`);
+        logger.forBot().info(`Channel ID ${newChannelId} found in channel list after ${attempt + 1} attempt(s).`);
         break;
       }
 
       const delay = Math.pow(2, attempt) * 1000;
-      logger.warn(`Channel ID ${newChannelId} not found yet. Retrying in ${delay / 1000}s...`);
+      logger.forBot().warn(`Channel ID ${newChannelId} not found yet. Retrying in ${delay / 1000}s...`);
       await sleep(delay);
       attempt++;
     }
 
     if (alreadyConnected) {
-      logger.info(`Channel ID ${newChannelId} is already connected. Skipping connection.`);
+      logger.forBot().info(`Channel ID ${newChannelId} is already connected. Skipping connection.`);
     } else {
       let connectChannel = await hubspotClient.connectCustomChannel(
         newChannelId,
         ctx.configuration.helpDeskId,
         channelName
       );
-      logger.info("Connected new custom channel to help desk.");
+      logger.forBot().info("Connected new custom channel to help desk.");
       // Save channelId to integration state
       await client.setState({
         id: ctx.integrationId,
@@ -66,15 +66,13 @@ export const register: RegisterFunction = async ({ ctx, client, logger }) => {
         payload: { 
           channelId: newChannelId, 
           channelAccountId: connectChannel.data.id,
-          integrationThreadId: "tempValue"
-
         },
       });
     }
 
-    logger.info("Hubspot configuration validated successfully.");
+    logger.forBot().info("Hubspot configuration validated successfully.");
   } catch (error) {
-    logger.error("Error during integration registration:", error);
+    logger.forBot().error("Error during integration registration:", error);
     throw new bpclient.RuntimeError(
       "Configuration Error! Unable to retrieve app details."
     );

--- a/integrations/hubspot-help-desk-hitl/src/setup/unregister.ts
+++ b/integrations/hubspot-help-desk-hitl/src/setup/unregister.ts
@@ -1,5 +1,5 @@
 import type { UnregisterFunction } from '../misc/types';
 
-export const unregister: UnregisterFunction = async ({ ctx, client, logger }) => {
+export const unregister: UnregisterFunction = async ({ logger }) => {
   logger.forBot().info("Unregister process for HubSpot Help Desk HITL integration invoked. No resources to clean up.");
 }


### PR DESCRIPTION
Similar fix made to hubspot-inbox-hitl, https://github.com/botpress/growth/pull/94

- Changed user relevant states to be user states instead of integration states to prevent thread mixups.
- Added more concise user tagging to support integrationThreadId, conversationId and agentId.
- Ensure the correct hubspot contactType is used (phone or email) based on what was initially provided when creating the user within Botpress.