### PR TITLE
chore(hitl-salesforce): update for hitl v2

### DIFF
--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/createUser/input.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/createUser/input.ts
@@ -4,13 +4,20 @@
 
 import { z } from "@botpress/sdk";
 export const input = {
-  schema: z.object({
-    name: /** Display name of the end user */ z.string(),
-    pictureUrl: /** URL of the end user's avatar */ z.optional(
-      /** URL of the end user's avatar */ z.string(),
-    ),
-    email: /** Email address of the end user */ z.optional(
-      /** Email address of the end user */ z.string(),
-    ),
-  }),
+  schema: z
+    .object({
+      name: z
+        .string()
+        .title("Display name")
+        .describe("Display name of the end user"),
+      pictureUrl: z
+        .optional(z.string().describe("URL of the end user's avatar"))
+        .title("Picture URL")
+        .describe("URL of the end user's avatar"),
+      email: z
+        .optional(z.string().describe("Email address of the end user"))
+        .title("Email address")
+        .describe("Email address of the end user"),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/createUser/output.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/createUser/output.ts
@@ -4,7 +4,12 @@
 
 import { z } from "@botpress/sdk";
 export const output = {
-  schema: z.object({
-    userId: /** ID of the Botpress user representing the end user */ z.string(),
-  }),
+  schema: z
+    .object({
+      userId: z
+        .string()
+        .title("Botpress user ID")
+        .describe("ID of the Botpress user representing the end user"),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/startHitl/input.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/startHitl/input.ts
@@ -4,286 +4,452 @@
 
 import { z } from "@botpress/sdk";
 export const input = {
-  schema: z.object({
-    userId: /** ID of the Botpress user representing the end user */ z.string(),
-    title:
-      /** Title of the HITL session. This corresponds to a ticket title in systems that use tickets. */ z.optional(
-        /** Title of the HITL session. This corresponds to a ticket title in systems that use tickets. */ z.string(),
-      ),
-    description:
-      /** Description of the HITL session. This corresponds to a ticket description in systems that use tickets. */ z.optional(
-        /** Description of the HITL session. This corresponds to a ticket description in systems that use tickets. */ z.string(),
-      ),
-    messageHistory: z.array(
-      z.union([
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("text"),
-          payload: z.object({
-            text: z.string(),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("image"),
-          payload: z.object({
-            imageUrl: z.string(),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("audio"),
-          payload: z.object({
-            audioUrl: z.string(),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("video"),
-          payload: z.object({
-            videoUrl: z.string(),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("file"),
-          payload: z.object({
-            fileUrl: z.string(),
-            title: z.optional(z.string()),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("location"),
-          payload: z.object({
-            latitude: z.number(),
-            longitude: z.number(),
-            address: z.optional(z.string()),
-            title: z.optional(z.string()),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("carousel"),
-          payload: z.object({
-            items: z.array(
-              z.object({
-                title: z.string(),
-                subtitle: z.optional(z.string()),
-                imageUrl: z.optional(z.string()),
-                actions: z.array(
-                  z.object({
-                    action: z.enum(["postback", "url", "say"]),
-                    label: z.string(),
-                    value: z.string(),
-                  }),
-                ),
-              }),
+  schema: z
+    .object({
+      userId: z
+        .string()
+        .title("User ID")
+        .describe("ID of the Botpress user representing the end user"),
+      title: z
+        .optional(
+          z
+            .string()
+            .describe(
+              "Title of the HITL session. This corresponds to a ticket title in systems that use tickets.",
             ),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("card"),
-          payload: z.object({
-            title: z.string(),
-            subtitle: z.optional(z.string()),
-            imageUrl: z.optional(z.string()),
-            actions: z.array(
-              z.object({
-                action: z.enum(["postback", "url", "say"]),
-                label: z.string(),
-                value: z.string(),
-              }),
+        )
+        .title("Title")
+        .describe(
+          "Title of the HITL session. This corresponds to a ticket title in systems that use tickets.",
+        ),
+      description: z
+        .optional(
+          z
+            .string()
+            .describe(
+              "Description of the HITL session. This corresponds to a ticket description in systems that use tickets.",
             ),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("dropdown"),
-          payload: z.object({
-            text: z.string(),
-            options: z.array(
-              z.object({
-                label: z.string(),
-                value: z.string(),
-              }),
-            ),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("choice"),
-          payload: z.object({
-            text: z.string(),
-            options: z.array(
-              z.object({
-                label: z.string(),
-                value: z.string(),
-              }),
-            ),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
-          ]),
-          type: z.literal("bloc"),
-          payload: z.object({
-            items: z.array(
-              z.union([
-                z.object({
-                  type: z.literal("text"),
-                  payload: z.object({
-                    text: z.string(),
-                  }),
-                }),
-                z.object({
-                  type: z.literal("markdown"),
-                  payload: z.object({
-                    markdown: z.string(),
-                  }),
-                }),
-                z.object({
-                  type: z.literal("image"),
-                  payload: z.object({
-                    imageUrl: z.string(),
-                  }),
-                }),
-                z.object({
-                  type: z.literal("audio"),
-                  payload: z.object({
-                    audioUrl: z.string(),
-                  }),
-                }),
-                z.object({
-                  type: z.literal("video"),
-                  payload: z.object({
-                    videoUrl: z.string(),
-                  }),
-                }),
-                z.object({
-                  type: z.literal("file"),
-                  payload: z.object({
-                    fileUrl: z.string(),
-                    title: z.optional(z.string()),
-                  }),
-                }),
-                z.object({
-                  type: z.literal("location"),
-                  payload: z.object({
+        )
+        .title("Description")
+        .describe(
+          "Description of the HITL session. This corresponds to a ticket description in systems that use tickets.",
+        ),
+      hitlSession: z
+        .optional(
+          z.ref("hitlSession").describe("Configuration of the HITL session"),
+        )
+        .title("Extra configuration")
+        .describe("Configuration of the HITL session"),
+      messageHistory: z
+        .array(
+          z.union([
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("text"),
+                payload: z
+                  .object({
+                    text: z.string().min(1, undefined),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("image"),
+                payload: z
+                  .object({
+                    imageUrl: z.string().min(1, undefined),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("audio"),
+                payload: z
+                  .object({
+                    audioUrl: z.string().min(1, undefined),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("video"),
+                payload: z
+                  .object({
+                    videoUrl: z.string().min(1, undefined),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("file"),
+                payload: z
+                  .object({
+                    fileUrl: z.string().min(1, undefined),
+                    title: z.optional(z.string().min(1, undefined)),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("location"),
+                payload: z
+                  .object({
                     latitude: z.number(),
                     longitude: z.number(),
                     address: z.optional(z.string()),
                     title: z.optional(z.string()),
-                  }),
-                }),
-              ]),
-            ),
-          }),
-        }),
-        z.object({
-          source: z.union([
-            z.object({
-              type: z.literal("user"),
-              userId: z.string(),
-            }),
-            z.object({
-              type: z.literal("bot"),
-            }),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("carousel"),
+                payload: z
+                  .object({
+                    items: z.array(
+                      z
+                        .object({
+                          title: z.string().min(1, undefined),
+                          subtitle: z.optional(z.string().min(1, undefined)),
+                          imageUrl: z.optional(z.string().min(1, undefined)),
+                          actions: z.array(
+                            z
+                              .object({
+                                action: z.enum(["postback", "url", "say"]),
+                                label: z.string().min(1, undefined),
+                                value: z.string().min(1, undefined),
+                              })
+                              .catchall(z.never()),
+                          ),
+                        })
+                        .catchall(z.never()),
+                    ),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("card"),
+                payload: z
+                  .object({
+                    title: z.string().min(1, undefined),
+                    subtitle: z.optional(z.string().min(1, undefined)),
+                    imageUrl: z.optional(z.string().min(1, undefined)),
+                    actions: z.array(
+                      z
+                        .object({
+                          action: z.enum(["postback", "url", "say"]),
+                          label: z.string().min(1, undefined),
+                          value: z.string().min(1, undefined),
+                        })
+                        .catchall(z.never()),
+                    ),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("dropdown"),
+                payload: z
+                  .object({
+                    text: z.string().min(1, undefined),
+                    options: z.array(
+                      z
+                        .object({
+                          label: z.string().min(1, undefined),
+                          value: z.string().min(1, undefined),
+                        })
+                        .catchall(z.never()),
+                    ),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("choice"),
+                payload: z
+                  .object({
+                    text: z.string().min(1, undefined),
+                    options: z.array(
+                      z
+                        .object({
+                          label: z.string().min(1, undefined),
+                          value: z.string().min(1, undefined),
+                        })
+                        .catchall(z.never()),
+                    ),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("bloc"),
+                payload: z
+                  .object({
+                    items: z.array(
+                      z.union([
+                        z
+                          .object({
+                            type: z.literal("text"),
+                            payload: z
+                              .object({
+                                text: z.string().min(1, undefined),
+                              })
+                              .catchall(z.never()),
+                          })
+                          .catchall(z.never()),
+                        z
+                          .object({
+                            type: z.literal("markdown"),
+                            payload: z
+                              .object({
+                                markdown: z.string().min(1, undefined),
+                              })
+                              .catchall(z.never()),
+                          })
+                          .catchall(z.never()),
+                        z
+                          .object({
+                            type: z.literal("image"),
+                            payload: z
+                              .object({
+                                imageUrl: z.string().min(1, undefined),
+                              })
+                              .catchall(z.never()),
+                          })
+                          .catchall(z.never()),
+                        z
+                          .object({
+                            type: z.literal("audio"),
+                            payload: z
+                              .object({
+                                audioUrl: z.string().min(1, undefined),
+                              })
+                              .catchall(z.never()),
+                          })
+                          .catchall(z.never()),
+                        z
+                          .object({
+                            type: z.literal("video"),
+                            payload: z
+                              .object({
+                                videoUrl: z.string().min(1, undefined),
+                              })
+                              .catchall(z.never()),
+                          })
+                          .catchall(z.never()),
+                        z
+                          .object({
+                            type: z.literal("file"),
+                            payload: z
+                              .object({
+                                fileUrl: z.string().min(1, undefined),
+                                title: z.optional(z.string().min(1, undefined)),
+                              })
+                              .catchall(z.never()),
+                          })
+                          .catchall(z.never()),
+                        z
+                          .object({
+                            type: z.literal("location"),
+                            payload: z
+                              .object({
+                                latitude: z.number(),
+                                longitude: z.number(),
+                                address: z.optional(z.string()),
+                                title: z.optional(z.string()),
+                              })
+                              .catchall(z.never()),
+                          })
+                          .catchall(z.never()),
+                      ]),
+                    ),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
+            z
+              .object({
+                source: z.union([
+                  z
+                    .object({
+                      type: z.literal("user"),
+                      userId: z.string(),
+                    })
+                    .catchall(z.never()),
+                  z
+                    .object({
+                      type: z.literal("bot"),
+                    })
+                    .catchall(z.never()),
+                ]),
+                type: z.literal("markdown"),
+                payload: z
+                  .object({
+                    markdown: z.string().min(1, undefined),
+                  })
+                  .catchall(z.never()),
+              })
+              .catchall(z.never()),
           ]),
-          type: z.literal("markdown"),
-          payload: z.object({
-            markdown: z.string(),
-          }),
-        }),
-      ]),
-    ),
-  }),
+        )
+        .title("Conversation history")
+        .describe(
+          "History of all messages in the conversation up to this point. Should be displayed to the human agent in the external service.",
+        ),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/startHitl/output.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/startHitl/output.ts
@@ -4,8 +4,14 @@
 
 import { z } from "@botpress/sdk";
 export const output = {
-  schema: z.object({
-    conversationId:
-      /** ID of the Botpress conversation representing the HITL session */ z.string(),
-  }),
+  schema: z
+    .object({
+      conversationId: z
+        .string()
+        .title("HITL session ID")
+        .describe(
+          "ID of the Botpress conversation representing the HITL session",
+        ),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/stopHitl/input.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/stopHitl/input.ts
@@ -4,8 +4,14 @@
 
 import { z } from "@botpress/sdk";
 export const input = {
-  schema: z.object({
-    conversationId:
-      /** ID of the Botpress conversation representing the HITL session */ z.string(),
-  }),
+  schema: z
+    .object({
+      conversationId: z
+        .string()
+        .title("HITL session ID")
+        .describe(
+          "ID of the Botpress conversation representing the HITL session",
+        ),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/audio.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/audio.ts
@@ -4,11 +4,18 @@
 
 import { z } from "@botpress/sdk";
 export const audio = {
-  schema: z.object({
-    audioUrl: z.string(),
-    userId:
-      /** Allows sending a message pretending to be a certain user */ z.optional(
-        /** Allows sending a message pretending to be a certain user */ z.string(),
-      ),
-  }),
+  schema: z
+    .object({
+      audioUrl: z.string().min(1, undefined),
+      userId: z
+        .optional(
+          z
+            .string()
+            .describe(
+              "Allows sending a message pretending to be a certain user",
+            ),
+        )
+        .describe("Allows sending a message pretending to be a certain user"),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/bloc.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/bloc.ts
@@ -4,60 +4,95 @@
 
 import { z } from "@botpress/sdk";
 export const bloc = {
-  schema: z.object({
-    items: z.array(
-      z.union([
-        z.object({
-          type: z.literal("text"),
-          payload: z.object({
-            text: z.string(),
-          }),
-        }),
-        z.object({
-          type: z.literal("markdown"),
-          payload: z.object({
-            markdown: z.string(),
-          }),
-        }),
-        z.object({
-          type: z.literal("image"),
-          payload: z.object({
-            imageUrl: z.string(),
-          }),
-        }),
-        z.object({
-          type: z.literal("audio"),
-          payload: z.object({
-            audioUrl: z.string(),
-          }),
-        }),
-        z.object({
-          type: z.literal("video"),
-          payload: z.object({
-            videoUrl: z.string(),
-          }),
-        }),
-        z.object({
-          type: z.literal("file"),
-          payload: z.object({
-            fileUrl: z.string(),
-            title: z.optional(z.string()),
-          }),
-        }),
-        z.object({
-          type: z.literal("location"),
-          payload: z.object({
-            latitude: z.number(),
-            longitude: z.number(),
-            address: z.optional(z.string()),
-            title: z.optional(z.string()),
-          }),
-        }),
-      ]),
-    ),
-    userId:
-      /** Allows sending a message pretending to be a certain user */ z.optional(
-        /** Allows sending a message pretending to be a certain user */ z.string(),
+  schema: z
+    .object({
+      items: z.array(
+        z.union([
+          z
+            .object({
+              type: z.literal("text"),
+              payload: z
+                .object({
+                  text: z.string().min(1, undefined),
+                })
+                .catchall(z.never()),
+            })
+            .catchall(z.never()),
+          z
+            .object({
+              type: z.literal("markdown"),
+              payload: z
+                .object({
+                  markdown: z.string().min(1, undefined),
+                })
+                .catchall(z.never()),
+            })
+            .catchall(z.never()),
+          z
+            .object({
+              type: z.literal("image"),
+              payload: z
+                .object({
+                  imageUrl: z.string().min(1, undefined),
+                })
+                .catchall(z.never()),
+            })
+            .catchall(z.never()),
+          z
+            .object({
+              type: z.literal("audio"),
+              payload: z
+                .object({
+                  audioUrl: z.string().min(1, undefined),
+                })
+                .catchall(z.never()),
+            })
+            .catchall(z.never()),
+          z
+            .object({
+              type: z.literal("video"),
+              payload: z
+                .object({
+                  videoUrl: z.string().min(1, undefined),
+                })
+                .catchall(z.never()),
+            })
+            .catchall(z.never()),
+          z
+            .object({
+              type: z.literal("file"),
+              payload: z
+                .object({
+                  fileUrl: z.string().min(1, undefined),
+                  title: z.optional(z.string().min(1, undefined)),
+                })
+                .catchall(z.never()),
+            })
+            .catchall(z.never()),
+          z
+            .object({
+              type: z.literal("location"),
+              payload: z
+                .object({
+                  latitude: z.number(),
+                  longitude: z.number(),
+                  address: z.optional(z.string()),
+                  title: z.optional(z.string()),
+                })
+                .catchall(z.never()),
+            })
+            .catchall(z.never()),
+        ]),
       ),
-  }),
+      userId: z
+        .optional(
+          z
+            .string()
+            .describe(
+              "Allows sending a message pretending to be a certain user",
+            ),
+        )
+        .describe("Allows sending a message pretending to be a certain user"),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/file.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/file.ts
@@ -4,12 +4,19 @@
 
 import { z } from "@botpress/sdk";
 export const file = {
-  schema: z.object({
-    fileUrl: z.string(),
-    title: z.optional(z.string()),
-    userId:
-      /** Allows sending a message pretending to be a certain user */ z.optional(
-        /** Allows sending a message pretending to be a certain user */ z.string(),
-      ),
-  }),
+  schema: z
+    .object({
+      fileUrl: z.string().min(1, undefined),
+      title: z.optional(z.string().min(1, undefined)),
+      userId: z
+        .optional(
+          z
+            .string()
+            .describe(
+              "Allows sending a message pretending to be a certain user",
+            ),
+        )
+        .describe("Allows sending a message pretending to be a certain user"),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/image.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/image.ts
@@ -4,11 +4,18 @@
 
 import { z } from "@botpress/sdk";
 export const image = {
-  schema: z.object({
-    imageUrl: z.string(),
-    userId:
-      /** Allows sending a message pretending to be a certain user */ z.optional(
-        /** Allows sending a message pretending to be a certain user */ z.string(),
-      ),
-  }),
+  schema: z
+    .object({
+      imageUrl: z.string().min(1, undefined),
+      userId: z
+        .optional(
+          z
+            .string()
+            .describe(
+              "Allows sending a message pretending to be a certain user",
+            ),
+        )
+        .describe("Allows sending a message pretending to be a certain user"),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/text.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/text.ts
@@ -4,11 +4,18 @@
 
 import { z } from "@botpress/sdk";
 export const text = {
-  schema: z.object({
-    text: z.string(),
-    userId:
-      /** Allows sending a message pretending to be a certain user */ z.optional(
-        /** Allows sending a message pretending to be a certain user */ z.string(),
-      ),
-  }),
+  schema: z
+    .object({
+      text: z.string().min(1, undefined),
+      userId: z
+        .optional(
+          z
+            .string()
+            .describe(
+              "Allows sending a message pretending to be a certain user",
+            ),
+        )
+        .describe("Allows sending a message pretending to be a certain user"),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/video.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/channels/hitl/messages/video.ts
@@ -4,11 +4,18 @@
 
 import { z } from "@botpress/sdk";
 export const video = {
-  schema: z.object({
-    videoUrl: z.string(),
-    userId:
-      /** Allows sending a message pretending to be a certain user */ z.optional(
-        /** Allows sending a message pretending to be a certain user */ z.string(),
-      ),
-  }),
+  schema: z
+    .object({
+      videoUrl: z.string().min(1, undefined),
+      userId: z
+        .optional(
+          z
+            .string()
+            .describe(
+              "Allows sending a message pretending to be a certain user",
+            ),
+        )
+        .describe("Allows sending a message pretending to be a certain user"),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/entities/hitlSession.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/entities/hitlSession.ts
@@ -3,6 +3,9 @@
 // This file is generated. Do not edit it manually.
 
 import { z } from "@botpress/sdk";
-export const output = {
+export const hitlSession = {
+  title: "HITL session",
+  description:
+    "A HITL session, often referred to as a ticket or conversation in external systems",
   schema: z.object({}).catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/entities/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/entities/index.ts
@@ -1,6 +1,9 @@
 /* eslint-disable */
 /* tslint:disable */
 // This file is generated. Do not edit it manually.
+import * as hitlSession from "./hitlSession";
+export * as hitlSession from "./hitlSession";
 
 export const entities = {
+  "hitlSession": hitlSession.hitlSession,
 }

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/events/hitlAssigned.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/events/hitlAssigned.ts
@@ -4,10 +4,21 @@
 
 import { z } from "@botpress/sdk";
 export const hitlAssigned = {
-  schema: z.object({
-    conversationId:
-      /** ID of the Botpress conversation representing the HITL session */ z.string(),
-    userId:
-      /** ID of the Botpress user representing the human agent assigned to the HITL session */ z.string(),
-  }),
+  attributes: { bpActionHiddenInStudio: "true" },
+  schema: z
+    .object({
+      conversationId: z
+        .string()
+        .title("HITL session ID")
+        .describe(
+          "ID of the Botpress conversation representing the HITL session",
+        ),
+      userId: z
+        .string()
+        .title("Human agent user ID")
+        .describe(
+          "ID of the Botpress user representing the human agent assigned to the HITL session",
+        ),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/events/hitlStopped.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/events/hitlStopped.ts
@@ -4,8 +4,15 @@
 
 import { z } from "@botpress/sdk";
 export const hitlStopped = {
-  schema: z.object({
-    conversationId:
-      /** ID of the Botpress conversation representing the HITL session */ z.string(),
-  }),
+  attributes: { bpActionHiddenInStudio: "true" },
+  schema: z
+    .object({
+      conversationId: z
+        .string()
+        .title("HITL session ID")
+        .describe(
+          "ID of the Botpress conversation representing the HITL session",
+        ),
+    })
+    .catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/events/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/events/index.ts
@@ -1,12 +1,12 @@
 /* eslint-disable */
 /* tslint:disable */
 // This file is generated. Do not edit it manually.
-import * as hitlAssigned from "./hitlAssigned";
-export * as hitlAssigned from "./hitlAssigned";
 import * as hitlStopped from "./hitlStopped";
 export * as hitlStopped from "./hitlStopped";
+import * as hitlAssigned from "./hitlAssigned";
+export * as hitlAssigned from "./hitlAssigned";
 
 export const events = {
-  "hitlAssigned": hitlAssigned.hitlAssigned,
   "hitlStopped": hitlStopped.hitlStopped,
+  "hitlAssigned": hitlAssigned.hitlAssigned,
 }

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/index.ts
@@ -15,7 +15,8 @@ export * as entities from "./entities/index"
 
 export default {
   name: "hitl",
-  version: "1.1.2",
+  version: "2.0.0",
+  attributes: {},
   actions: actions.actions,
   channels: channels.channels,
   events: events.events,

--- a/integrations/hitl-salesforce/bp_modules/hitl/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/index.ts
@@ -8,9 +8,9 @@ import definition from "./definition"
 
 export default {
   type: "interface",
-  id: "ifver_01JTK2KEBVHQYKAJVFGVC4SSJK",
+  id: "ifver_01JY472MTT0ZN6S4MDMRRC17G5",
   uri: undefined,
   name: "hitl",
-  version: "1.1.2",
+  version: "2.0.0",
   definition,
 } satisfies sdk.InterfacePackage

--- a/integrations/hitl-salesforce/integration.definition.ts
+++ b/integrations/hitl-salesforce/integration.definition.ts
@@ -1,4 +1,4 @@
-import { IntegrationDefinition, IntegrationDefinitionProps } from '@botpress/sdk'
+import { IntegrationDefinition, IntegrationDefinitionProps, z } from '@botpress/sdk'
 import { integrationName } from './package.json'
 import hitl from './bp_modules/hitl'
 import { configuration, channels, states, events, actions } from './src/definitions'
@@ -14,7 +14,7 @@ export const user = {
 export default new IntegrationDefinition({
   name: integrationName,
   title: 'SalesForce Messaging (Alpha)',
-  version: '0.3.2',
+  version: '0.4.0',
   icon: 'icon.svg',
   description:
     'This integration allows your bot to interact with Salesforce Messaging, this version uses the HITL Interface',
@@ -35,8 +35,15 @@ export default new IntegrationDefinition({
       optional: false,
     },
   },
-}).extend(hitl, () => ({
-  entities: {},
+  entities: {
+    hitlTicket: {
+      schema: z.object({}),
+    },
+  },
+}).extend(hitl, (self) => ({
+  entities: {
+    hitlSession: self.entities.hitlTicket,
+  },
   channels: {
     hitl: {
       conversation: {

--- a/integrations/hitl-salesforce/package.json
+++ b/integrations/hitl-salesforce/package.json
@@ -5,9 +5,8 @@
   "description": "Integration for HITL Salesforce Messaging",
   "private": true,
   "scripts": {
-    "add-interface": "pnpm bp add  interface:hitl@latest --y",
     "start": "pnpm bp serve",
-    "build": "pnpm bp build",
+    "build": "pnpm bp add -y && pnpm bp build",
     "deploy": "pnpm bp deploy",
     "login": "pnpm bp login",
     "test": "echo \"Tests not implemented yet.\"",
@@ -19,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@botpress/client": "1.15.1",
-    "@botpress/sdk": "4.8.3",
+    "@botpress/sdk": "4.11.0",
     "@typescript-eslint/eslint-plugin": "^5.47.0",
     "@typescript-eslint/parser": "^5.47.0",
     "axios": "^1.7.3",
@@ -36,7 +35,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@botpress/cli": "4.8.5",
+    "@botpress/cli": "4.9.0",
     "@types/lodash": "^4.14.191",
     "@types/ms": "^0.7.34",
     "@types/node": "^18.11.17",
@@ -48,5 +47,8 @@
     "eslint-plugin-promise": "^6.6.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
+  },
+  "bpDependencies": {
+    "hitl": "interface:hitl@2.0.0"
   }
 }

--- a/integrations/hitl-salesforce/pnpm-lock.yaml
+++ b/integrations/hitl-salesforce/pnpm-lock.yaml
@@ -1,12 +1,16 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@botpress/client':
     specifier: 1.15.1
     version: 1.15.1
   '@botpress/sdk':
-    specifier: 4.8.3
-    version: 4.8.3(@bpinternal/zui@1.0.0)(esbuild@0.16.17)
+    specifier: 4.11.0
+    version: 4.11.0(@bpinternal/zui@1.0.0)(esbuild@0.16.17)
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.47.0
     version: 5.47.0(@typescript-eslint/parser@5.47.0)(eslint@8.57.1)(typescript@4.9.5)
@@ -52,8 +56,8 @@ dependencies:
 
 devDependencies:
   '@botpress/cli':
-    specifier: 4.8.5
-    version: 4.8.5(@bpinternal/zui@1.0.0)
+    specifier: 4.9.0
+    version: 4.9.0(@bpinternal/zui@1.0.0)
   '@types/lodash':
     specifier: ^4.14.191
     version: 4.14.191
@@ -106,15 +110,15 @@ packages:
       - debug
     dev: true
 
-  /@botpress/cli@4.8.5(@bpinternal/zui@1.0.0):
-    resolution: {integrity: sha512-dmug8eCFOJwWgdJtZOJUKPOQjw06/R905C4GQvufQo7TV6aUNnS6ZyGGeyBrpFHOSLqYGLw/el8MDWP+RNVQIw==}
+  /@botpress/cli@4.9.0(@bpinternal/zui@1.0.0):
+    resolution: {integrity: sha512-PArCSzbCyWA6MF6IXLk88dLyUI8BTVmFaUiLJKK7efOOAAN22iWJARDg0HonsQlCO1IH2SVcvmbvDjfTYFnrdg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
       '@apidevtools/json-schema-ref-parser': 11.7.2
       '@botpress/chat': 0.5.1
-      '@botpress/client': 1.15.1
-      '@botpress/sdk': 4.8.3(@bpinternal/zui@1.0.0)(esbuild@0.16.17)
+      '@botpress/client': 1.15.3
+      '@botpress/sdk': 4.11.0(@bpinternal/zui@1.0.0)(esbuild@0.16.17)
       '@bpinternal/const': 0.1.0
       '@bpinternal/tunnel': 0.1.17
       '@bpinternal/yargs-extra': 0.0.3
@@ -157,9 +161,21 @@ packages:
       qs: 6.13.0
     transitivePeerDependencies:
       - debug
+    dev: false
 
-  /@botpress/sdk@4.8.3(@bpinternal/zui@1.0.0)(esbuild@0.16.17):
-    resolution: {integrity: sha512-T+ODQIfTroMrzAU88YklYy2qvtsLeEe7v4q71dqzR/PRmRfgzrCDF4K7DUrCRiHGSX2pqnO3jo2I06w26O9OCA==}
+  /@botpress/client@1.15.3:
+    resolution: {integrity: sha512-B9jVeE3htq/Pw6levCggkvCQNbYJyt9bBAofmiDOPMhEMpArrJa4ECQMshxn6qD1MV6Xxo6tZxPvqgn5HAkSnw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      axios: 1.7.3
+      axios-retry: 4.5.0(axios@1.7.3)
+      browser-or-node: 2.1.1
+      qs: 6.13.0
+    transitivePeerDependencies:
+      - debug
+
+  /@botpress/sdk@4.11.0(@bpinternal/zui@1.0.0)(esbuild@0.16.17):
+    resolution: {integrity: sha512-jPxHASaBUeW2+NevRdra37Q1tvqmPfmzhAlnJflros2dV+rSe/gUs5VGDJWQrxyEcCll4Qeg5CpyloJ5tb0Uww==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@bpinternal/zui': ^1.0.0
@@ -168,7 +184,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@botpress/client': 1.15.1
+      '@botpress/client': 1.15.3
       '@bpinternal/zui': 1.0.0
       browser-or-node: 2.1.1
       esbuild: 0.16.17


### PR DESCRIPTION
The HITL interface now defines an `hitlSession` entity, which every hitl integration _must_ extend. This interface defines extra fields that integrations can set on tickets ([see Zendesk for example](https://github.com/botpress/botpress/blob/master/integrations/zendesk/integration.definition.ts#L23)).

This PR:
- updates the CLI and SDK for hitl-salesforce
- updates the hitl interface to 2.0.0
- adds an empty `hitlConversation` entity to extend the `hitlSession` entity of the `hitl` interface

**Important:** the Studio is missing support for server-side plugin merging. This means that we could not deploy the new version of the hitl plugin and interface in production yet. Please **do not publish this version of the hitl-salesforce integration to production** until version 2.0.0 of the hitl interface is available in production. This version of the integration can safely be used in staging in bots-as-code (not yet in the Studio) in the meantime.

<sub> Contributes to [DEV-3044](https://linear.app/botpress/issue/DEV-3044/interfaces-hitl-add-ticket-entity-and-use-it-in-starthitl) </sub>