### PR TITLE
chore(integrations/help-desk): bumping by a major

### DIFF
--- a/integrations/hubspot-help-desk-hitl/integration.definition.ts
+++ b/integrations/hubspot-help-desk-hitl/integration.definition.ts
@@ -7,7 +7,7 @@ import { events, configuration, states, channels, user } from './src/definitions
 export default new IntegrationDefinition({
   name: integrationName,
   title: 'HubSpot Help Desk HITL',
-  version: '1.0.3',
+  version: '2.0.0',
   icon: 'icon.svg',
   description: 'This integration allows your bot to use HubSpot as a HITL provider. Messages will appear in HubSpot Help Desk.',
   readme: 'hub.md',


### PR DESCRIPTION
User tag "id" has been removed from version 1.0.2. This caused a breaking change between the minor versions as the entire integration schema had changed. Therefore, we needed to bump by a major to ensure proper deployment without breaking everything.

