### PR TITLE
feat(hitl-salesforce): add routing parameters

### DIFF
--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/createUser/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/createUser/index.ts
@@ -9,8 +9,6 @@ export * as output from "./output";
 export const createUser = {
   "input": input.input,
   "output": output.output,
-  "title": "Create external user",
-  "description": "Create an end user in the external service and in Botpress",
   "billable": false,
   "cacheable": false,
   "attributes": { "bpActionHiddenInStudio": "true" },

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/startHitl/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/startHitl/index.ts
@@ -9,8 +9,6 @@ export * as output from "./output";
 export const startHitl = {
   "input": input.input,
   "output": output.output,
-  "title": "Start new HITL session",
-  "description": "Create a new HITL session in the external service and in Botpress",
   "billable": false,
   "cacheable": false,
   "attributes": { "bpActionHiddenInStudio": "true" },

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/stopHitl/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/actions/stopHitl/index.ts
@@ -9,8 +9,6 @@ export * as output from "./output";
 export const stopHitl = {
   "input": input.input,
   "output": output.output,
-  "title": "Stop HITL session",
-  "description": "Stop an existing HITL session in the external service",
   "billable": false,
   "cacheable": false,
   "attributes": { "bpActionHiddenInStudio": "true" },

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/entities/hitlSession.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/entities/hitlSession.ts
@@ -4,8 +4,5 @@
 
 import { z } from "@botpress/sdk";
 export const hitlSession = {
-  title: "HITL session",
-  description:
-    "A HITL session, often referred to as a ticket or conversation in external systems",
   schema: z.object({}).catchall(z.never()),
 };

--- a/integrations/hitl-salesforce/bp_modules/hitl/definition/events/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/definition/events/index.ts
@@ -1,12 +1,12 @@
 /* eslint-disable */
 /* tslint:disable */
 // This file is generated. Do not edit it manually.
-import * as hitlStopped from "./hitlStopped";
-export * as hitlStopped from "./hitlStopped";
 import * as hitlAssigned from "./hitlAssigned";
 export * as hitlAssigned from "./hitlAssigned";
+import * as hitlStopped from "./hitlStopped";
+export * as hitlStopped from "./hitlStopped";
 
 export const events = {
-  "hitlStopped": hitlStopped.hitlStopped,
   "hitlAssigned": hitlAssigned.hitlAssigned,
+  "hitlStopped": hitlStopped.hitlStopped,
 }

--- a/integrations/hitl-salesforce/bp_modules/hitl/index.ts
+++ b/integrations/hitl-salesforce/bp_modules/hitl/index.ts
@@ -8,7 +8,7 @@ import definition from "./definition"
 
 export default {
   type: "interface",
-  id: "ifver_01JY472MTT0ZN6S4MDMRRC17G5",
+  id: "ifver_01K0STHY79Y0GFGFGDXXGQKDVE",
   uri: undefined,
   name: "hitl",
   version: "2.0.0",

--- a/integrations/hitl-salesforce/integration.definition.ts
+++ b/integrations/hitl-salesforce/integration.definition.ts
@@ -14,7 +14,7 @@ export const user = {
 export default new IntegrationDefinition({
   name: integrationName,
   title: 'SalesForce Messaging (Alpha)',
-  version: '0.4.0',
+  version: '0.5.0',
   icon: 'icon.svg',
   description:
     'This integration allows your bot to interact with Salesforce Messaging, this version uses the HITL Interface',
@@ -37,7 +37,22 @@ export default new IntegrationDefinition({
   },
   entities: {
     hitlTicket: {
-      schema: z.object({}),
+      schema: z.object({
+        routingParameters: z
+            .string()
+            .title('Routing Parameters')
+            .displayAs<any>({
+              id: 'text',
+              params: {
+                allowDynamicVariable: true,
+                growVertically: true,
+              },
+            })
+            .placeholder('{ "myParameter": "myParameterValue" }')
+            .default('{}')
+            .optional()
+            .describe('Custom properties to be used as routing parameters, use JSON format'),
+      }),
     },
   },
 }).extend(hitl, (self) => ({

--- a/integrations/hitl-salesforce/integration.definition.ts
+++ b/integrations/hitl-salesforce/integration.definition.ts
@@ -38,20 +38,21 @@ export default new IntegrationDefinition({
   entities: {
     hitlTicket: {
       schema: z.object({
-        routingParameters: z
+        routingAttributes: z
             .string()
-            .title('Routing Parameters')
+            .title('Routing Attributes')
             .displayAs<any>({
               id: 'text',
               params: {
                 allowDynamicVariable: true,
                 growVertically: true,
+                multiLine: true,
               },
             })
-            .placeholder('{ "myParameter": "myParameterValue" }')
+            .placeholder('{ "myAttribute": "myAttributeValue" }')
             .default('{}')
             .optional()
-            .describe('Custom properties to be used as routing parameters, use JSON format'),
+            .describe('Custom properties to be used as routing attributes, use JSON format'),
       }),
     },
   },

--- a/integrations/hitl-salesforce/package.json
+++ b/integrations/hitl-salesforce/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@botpress/client": "1.15.1",
-    "@botpress/sdk": "4.11.0",
+    "@botpress/sdk": "4.14.3",
     "@typescript-eslint/eslint-plugin": "^5.47.0",
     "@typescript-eslint/parser": "^5.47.0",
     "axios": "^1.7.3",
@@ -35,7 +35,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@botpress/cli": "4.9.0",
+    "@botpress/cli": "4.11.3",
     "@types/lodash": "^4.14.191",
     "@types/ms": "^0.7.34",
     "@types/node": "^18.11.17",

--- a/integrations/hitl-salesforce/src/actions/hitl.ts
+++ b/integrations/hitl-salesforce/src/actions/hitl.ts
@@ -54,6 +54,10 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async ({ c
 
     const splitName = user.name?.split(' ')
 
+    const { routingParameters } = input.hitlSession || {}
+
+    logger.forBot().debug(`Will use custom routing parameters: ${JSON.stringify({routingParameters})}`)
+
     await salesforceClient.createConversation(newSalesforceConversationId, {
       firstName: (splitName?.length && splitName[0]) || 'Anon',
       _lastName: (splitName && splitName?.length > 1 && splitName[splitName.length]) || '',

--- a/integrations/hitl-salesforce/src/actions/hitl.ts
+++ b/integrations/hitl-salesforce/src/actions/hitl.ts
@@ -54,21 +54,25 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async ({ c
 
     const splitName = user.name?.split(' ')
 
-    let routingParametersObj: Record<string, any> = {}
+    let routingAttributesObj: Record<string, any> = {}
 
     try {
-      routingParametersObj = JSON.parse(input.hitlSession?.routingParameters || '{}')
-      logger.forBot().debug(`Will use custom routing parameters: ${JSON.stringify({routingParametersObj})}`)
+      routingAttributesObj = JSON.parse(input.hitlSession?.routingAttributes || '{}')
+      logger.forBot().debug(`Will use custom routing attributes: ${JSON.stringify({routingAttributesObj})}`)
     } catch (thrown) {
       const err = thrown instanceof Error ? thrown : new Error(String(thrown))
-      logger.forBot().warn('Failed to parse routing parameters, using empty object: ' + err.message)
+      logger.forBot().warn('Failed to parse routing attributes, using empty object: ' + err.message)
     }
 
+
+    const name = (splitName?.length && splitName[0]) || 'Anon'
+
     await salesforceClient.createConversation(newSalesforceConversationId, {
-      firstName: (splitName?.length && splitName[0]) || 'Anon',
+      _firstName: name,
+      firstName: name, //backwards compatibility
       _lastName: (splitName && splitName?.length > 1 && splitName[splitName.length]) || '',
-      _email: user.tags?.email || 'anon@email.com',
-      ...routingParametersObj
+      _email: user.tags?.email  || 'anon@email.com',
+      ...routingAttributesObj
     })
 
     await client.createEvent({


### PR DESCRIPTION
This adds the ability to specify dynamic custom routing attributes at the "Start HITL" card

<img width="719" height="415" alt="image" src="https://github.com/user-attachments/assets/bceda407-1871-42d0-8f45-1cb35709e3c2" />

<img width="1473" height="580" alt="image" src="https://github.com/user-attachments/assets/c247a29f-65ae-4594-bbaa-6b2d682ad502" />
