### PR TITLE
Sync products to BP table in the background

### DIFF
--- a/integrations/magento2/hub.md
+++ b/integrations/magento2/hub.md
@@ -29,11 +29,11 @@ This Botpress integration allows seamless interaction with **Magento 2 (Adobe Co
    - `User Content` > `All Reviews`
    - `Reports` > `Reviews` (By Customers, By Products)
    - `Attributes` > `Product`, `Attribute Set`, `Ratings`, `Swatches`
-   
+
    > **Note:** These additional API scopes are required for full product, review, and attribute support in the integration.
-   > 
+   >
    > **To enable review functionality, you must also install the Reviews API module:**
-   > 
+   >
    > ```sh
    > composer require divante/magento2-review-api
    >
@@ -41,6 +41,7 @@ This Botpress integration allows seamless interaction with **Magento 2 (Adobe Co
    > ```
    >
    > This ensures the necessary endpoints for product reviews are available in your Magento instance.
+
 6. Return to the **Integration Info** tab, enter your admin password, and click **Save**
 7. In the integrations list, click **Activate** next to your new integration
 8. Copy the following credentials:
@@ -75,20 +76,19 @@ Retrieve products from your Magento catalog using flexible search criteria.
 #### **Input Example**
 
 **Filter by Price:**
+
 ```json
-[
-  { "field": "price", "condition": "gt", "value": "100" }
-]
+[{ "field": "price", "condition": "gt", "value": "100" }]
 ```
 
 **Filter by SKU:**
+
 ```json
-[
-  { "field": "sku", "condition": "eq", "value": "24-MB01" }
-]
+[{ "field": "sku", "condition": "eq", "value": "24-MB01" }]
 ```
 
 #### **Output**
+
 ```json
 {
   "result": {
@@ -97,7 +97,7 @@ Retrieve products from your Magento catalog using flexible search criteria.
         "id": 1,
         "sku": "24-MB01",
         "name": "Joust Duffle Bag",
-        "price": 34.00,
+        "price": 34.0,
         "type_id": "simple",
         "created_at": "2023-01-01 00:00:00",
         "updated_at": "2023-01-01 00:00:00"
@@ -114,11 +114,13 @@ Retrieve products from your Magento catalog using flexible search criteria.
 Get real-time stock information for a specific product by SKU.
 
 #### **Input Parameters**
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `sku` | String | Yes | The SKU of the product to get stock information for |
+
+| Parameter | Type   | Required | Description                                         |
+| --------- | ------ | -------- | --------------------------------------------------- |
+| `sku`     | String | Yes      | The SKU of the product to get stock information for |
 
 #### **Usage Example**
+
 ```json
 {
   "sku": "24-MB01"
@@ -126,6 +128,7 @@ Get real-time stock information for a specific product by SKU.
 ```
 
 #### **Output**
+
 ```json
 {
   "qty": 50,
@@ -138,71 +141,64 @@ Get real-time stock information for a specific product by SKU.
 Automatically sync products from Magento to a Botpress table with intelligent schema creation. Large syncs are automatically split across multiple webhook executions to handle timeouts.
 
 #### **Input Parameters**
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `table_name` | String | Yes | Name of the Botpress table to sync products to |
-| `custom_attributes` | String | No | Comma-separated list of custom product attributes |
-| `filters_json` | String | No | JSON array of filter objects for selective syncing |
+
+| Parameter                        | Type    | Required | Description                                                   |
+| -------------------------------- | ------- | -------- | ------------------------------------------------------------- |
+| `table_name`                     | String  | Yes      | Name of the Botpress table to sync products to                |
+| `custom_columns_to_add_to_table` | String  | No       | Comma-separated list of custom product attributes             |
+| `filters_json`                   | String  | No       | JSON array of filter objects for selective syncing            |
+| `retreive_reviews`               | Boolean | No       | Whether to fetch and include product reviews (default: false) |
 
 #### **Webhook Continuation Setup**
 
-For large product catalogs, the sync action automatically continues in batches using the `magentoSyncContinue` event. To ensure the sync completes, you must:
-
-1. **Create a Trigger** for the `magentoSyncContinue` event in your Botpress workflow.
-2. **Connect the Trigger** to a node that runs the "Sync Products To Botpress Table" action.
-3. **Map all input fields** in the action node to the corresponding values from `event.payload`.
-
-**Example field mappings:**
-
-| Action Input                | Value                                 |
-|----------------------------|---------------------------------------|
-| Table Name                  | `{{event.payload.table_name}}`         |
-| Custom Attributes           | `{{event.payload.custom_attributes}}`  |
-| Filters JSON                | `{{event.payload.filters_json}}`       |
-| Current Page                | `{{event.payload._currentPage}}`       |
-| Total Count                 | `{{event.payload._totalCount}}`        |
-| Table ID                    | `{{event.payload._tableId}}`           |
-| Run ID                      | `{{event.payload._runId}}`             |
-| Custom Attribute Codes      | `{{event.payload._customAttributeCodes}}` |
-| Attribute Mappings          | `{{event.payload._attributeMappings}}` |
-| Filter Criteria             | `{{event.payload._filterCriteria}}`    |
-| Current Page Product Index  | `{{event.payload._currentPageProductIndex}}` |
-
+For large product catalogs, the sync action automatically continues in batches using webhook.
 **No manual intervention is required**—the sync will continue automatically until all products are processed.
 
 #### **Default Table Schema**
+
 The integration automatically creates a table with the following columns:
 
-| Column Name | Type | Description |
-|-------------|------|-------------|
-| `sku` | text | Product SKU (required, unique) |
-| `name` | text | Product name |
-| `description` | text | Product description |
-| `price` | number | Product price |
-| `original_price` | number | Original price (if available) |
-| `currency` | text | Currency code (e.g., USD) |
-| `image_url` | text | Main product image URL |
-| `thumbnail_url` | text | Thumbnail image URL |
-| `stock_qty` | number | Quantity in stock |
-| `is_in_stock` | boolean | Whether the product is in stock |
-| `average_rating` | number | Average review rating |
-| `review_count` | number | Number of reviews |
+| Column Name      | Type    | Description                                                          |
+| ---------------- | ------- | -------------------------------------------------------------------- |
+| `sku`            | text    | Product SKU (required, unique)                                       |
+| `name`           | text    | Product name                                                         |
+| `description`    | text    | Product description                                                  |
+| `price`          | number  | Product price                                                        |
+| `original_price` | number  | Original price (if available)                                        |
+| `currency`       | text    | Currency code (e.g., USD)                                            |
+| `image_url`      | text    | Main product image URL                                               |
+| `thumbnail_url`  | text    | Thumbnail image URL                                                  |
+| `stock_qty`      | number  | Quantity in stock                                                    |
+| `is_in_stock`    | boolean | Whether the product is in stock                                      |
+| `average_rating` | number  | Average review rating (only populated if `retreive_reviews` is true) |
+| `review_count`   | number  | Number of reviews (only populated if `retreive_reviews` is true)     |
 
 #### **Usage Examples**
 
 **Basic Sync:**
+
 - **Table Name:** magento_products
 
 **With Custom Attributes:**
+
 - **Table Name:** magento_products
-- **Custom Attributes:** color,brand,size,material
+- **Custom Columns to Add to Table:** color,brand,size,material
 
 **With Filtering:**
+
 - **Table Name:** magento_products
-- **Custom Attributes:** color,tent_type
+- **Custom Columns to Add to Table:** color,tent_type
 - **Filters JSON:** [{"field": "price", "condition": "gt", "value": "50"}]
 
+**With Reviews Enabled:**
+
+- **Table Name:** magento_products
+- **Custom Columns to Add to Table:** color,brand
+- **Retrieve Reviews:** true
+- **Filters JSON:** [{"field": "price", "condition": "gt", "value": "100"}]
+
 #### **Output**
+
 ```json
 {
   "success": true,
@@ -220,25 +216,25 @@ The integration automatically creates a table with the following columns:
 
 When using `filters_json` in the sync action, you can use the following conditions based on the [Adobe Commerce REST API documentation](https://developer.adobe.com/commerce/webapi/rest/use-rest/performing-searches/#logical-and-and-or-search):
 
-| Condition | Description | Example |
-|-----------|-------------|---------|
-| `eq` | Equals | `{"field": "sku", "condition": "eq", "value": "24-MB01"}` |
-| `neq` | Not equal | `{"field": "price", "condition": "neq", "value": "0"}` |
-| `gt` | Greater than | `{"field": "price", "condition": "gt", "value": "100"}` |
-| `gteq` | Greater than or equal | `{"field": "price", "condition": "gteq", "value": "50"}` |
-| `lt` | Less than | `{"field": "price", "condition": "lt", "value": "200"}` |
-| `lteq` | Less than or equal | `{"field": "price", "condition": "lteq", "value": "150"}` |
-| `from` | Beginning of a range (must be used with `to`) | `{"field": "price", "condition": "from", "value": "50"}` |
-| `to` | End of a range (must be used with `from`) | `{"field": "price", "condition": "to", "value": "200"}` |
-| `like` | Like (supports SQL wildcard characters) | `{"field": "name", "condition": "like", "value": "jacket"}` |
-| `nlike` | Not like | `{"field": "name", "condition": "nlike", "value": "test"}` |
-| `in` | In (comma-separated list of values) | `{"field": "sku", "condition": "in", "value": "SKU1,SKU2,SKU3"}` |
-| `nin` | Not in (comma-separated list of values) | `{"field": "sku", "condition": "nin", "value": "SKU1,SKU2"}` |
-| `finset` | A value within a set of values | `{"field": "category_id", "condition": "finset", "value": "5"}` |
-| `nfinset` | A value that is not within a set of values | `{"field": "category_id", "condition": "nfinset", "value": "5"}` |
-| `moreq` | More or equal | `{"field": "price", "condition": "moreq", "value": "100"}` |
-| `null` | Is null | `{"field": "description", "condition": "null"}` |
-| `notnull` | Not null | `{"field": "color", "condition": "notnull"}` |
+| Condition | Description                                   | Example                                                          |
+| --------- | --------------------------------------------- | ---------------------------------------------------------------- |
+| `eq`      | Equals                                        | `{"field": "sku", "condition": "eq", "value": "24-MB01"}`        |
+| `neq`     | Not equal                                     | `{"field": "price", "condition": "neq", "value": "0"}`           |
+| `gt`      | Greater than                                  | `{"field": "price", "condition": "gt", "value": "100"}`          |
+| `gteq`    | Greater than or equal                         | `{"field": "price", "condition": "gteq", "value": "50"}`         |
+| `lt`      | Less than                                     | `{"field": "price", "condition": "lt", "value": "200"}`          |
+| `lteq`    | Less than or equal                            | `{"field": "price", "condition": "lteq", "value": "150"}`        |
+| `from`    | Beginning of a range (must be used with `to`) | `{"field": "price", "condition": "from", "value": "50"}`         |
+| `to`      | End of a range (must be used with `from`)     | `{"field": "price", "condition": "to", "value": "200"}`          |
+| `like`    | Like (supports SQL wildcard characters)       | `{"field": "name", "condition": "like", "value": "jacket"}`      |
+| `nlike`   | Not like                                      | `{"field": "name", "condition": "nlike", "value": "test"}`       |
+| `in`      | In (comma-separated list of values)           | `{"field": "sku", "condition": "in", "value": "SKU1,SKU2,SKU3"}` |
+| `nin`     | Not in (comma-separated list of values)       | `{"field": "sku", "condition": "nin", "value": "SKU1,SKU2"}`     |
+| `finset`  | A value within a set of values                | `{"field": "category_id", "condition": "finset", "value": "5"}`  |
+| `nfinset` | A value that is not within a set of values    | `{"field": "category_id", "condition": "nfinset", "value": "5"}` |
+| `moreq`   | More or equal                                 | `{"field": "price", "condition": "moreq", "value": "100"}`       |
+| `null`    | Is null                                       | `{"field": "description", "condition": "null"}`                  |
+| `notnull` | Not null                                      | `{"field": "color", "condition": "notnull"}`                     |
 
 ### Filter Examples
 
@@ -247,13 +243,13 @@ When using `filters_json` in the sync action, you can use the following conditio
 **Table Name:**
 magentoProducts
 
-**Custom Attributes:**
+**Custom Columns to Add to Table:**
 (leave blank or enter your custom attributes)
 
 **Filters JSON:**
 [
-  { "field": "price", "condition": "gteq", "value": "50" },
-  { "field": "price", "condition": "lteq", "value": "200" }
+{ "field": "price", "condition": "gteq", "value": "50" },
+{ "field": "price", "condition": "lteq", "value": "200" }
 ]
 
 ---
@@ -263,13 +259,13 @@ magentoProducts
 **Table Name:**
 magentoProducts
 
-**Custom Attributes:**
+**Custom Columns to Add to Table:**
 color,brand
 
 **Filters JSON:**
 [
-  { "field": "color", "condition": "notnull" },
-  { "field": "brand", "condition": "eq", "value": "Nike" }
+{ "field": "color", "condition": "notnull" },
+{ "field": "brand", "condition": "eq", "value": "Nike" }
 ]
 
 ---
@@ -279,12 +275,12 @@ color,brand
 **Table Name:**
 magentoProducts
 
-**Custom Attributes:**
+**Custom Columns to Add to Table:**
 (leave blank or enter your custom attributes)
 
 **Filters JSON:**
 [
-  { "field": "sku", "condition": "neq", "value": "" }
+{ "field": "sku", "condition": "neq", "value": "" }
 ]
 
 ---
@@ -292,29 +288,32 @@ magentoProducts
 ### Logical AND and OR Operations
 
 **Logical AND (multiple filter groups):**
+
 ```json
 [
-  {"field": "price", "condition": "gteq", "value": "50"},
-  {"field": "price", "condition": "lteq", "value": "200"},
-  {"field": "status", "condition": "eq", "value": "1"}
+  { "field": "price", "condition": "gteq", "value": "50" },
+  { "field": "price", "condition": "lteq", "value": "200" },
+  { "field": "status", "condition": "eq", "value": "1" }
 ]
 ```
 
 **Logical OR (multiple filters in same group):**
+
 ```json
 [
-  {"field": "sku", "condition": "like", "value": "WSH%"},
-  {"field": "sku", "condition": "like", "value": "WP%"}
+  { "field": "sku", "condition": "like", "value": "WSH%" },
+  { "field": "sku", "condition": "like", "value": "WP%" }
 ]
 ```
 
 **Complex AND/OR combination:**
+
 ```json
 [
-  {"field": "sku", "condition": "like", "value": "WSH%"},
-  {"field": "sku", "condition": "like", "value": "WP%"},
-  {"field": "price", "condition": "from", "value": "40"},
-  {"field": "price", "condition": "to", "value": "49.99"}
+  { "field": "sku", "condition": "like", "value": "WSH%" },
+  { "field": "sku", "condition": "like", "value": "WP%" },
+  { "field": "price", "condition": "from", "value": "40" },
+  { "field": "price", "condition": "to", "value": "49.99" }
 ]
 ```
 
@@ -331,12 +330,16 @@ For advanced product filtering, refer to the [Adobe Commerce API Documentation](
 ## Best Practices
 
 ### Performance Optimization
+
 - Use specific search criteria to reduce response times
 
 ### Data Management
-- Use custom attributes to include relevant product information
+
+- Use custom columns to add to table to include relevant product information
+- Enable reviews retrieval for products that have customer feedback
 
 ### Security
+
 - Keep your OAuth credentials secure
 
 ---
@@ -345,4 +348,3 @@ For advanced product filtering, refer to the [Adobe Commerce API Documentation](
 
 - [Adobe Commerce API Documentation](https://developer.adobe.com/commerce/webapi/rest/)
 - [Botpress Tables API](https://botpress.com/docs/learn/reference/tables)
-

--- a/integrations/magento2/hub.md
+++ b/integrations/magento2/hub.md
@@ -56,7 +56,7 @@ This Botpress integration allows seamless interaction with **Magento 2 (Adobe Co
 2. Find and enable the **Magento 2** integration
 3. Enter the following configuration:
    - **Magento Domain URL** (e.g., `www.yourstore.com`)
-   - **Store Code** (optional, defaults to `/all` - see Store Code section below)
+   - **Store Code** (optional, defaults to `all` - see Store Code section below)
    - **Consumer Key**
    - **Consumer Secret**
    - **Access Token**
@@ -74,7 +74,7 @@ The **Store Code** parameter allows you to specify which Magento store view to u
 
 ### Default Behavior
 
-- **Default Value:** `/all` (accesses all store views)
+- **Default Value:** `all` (accesses all store views)
 - **When to use:** Single-store installations or when you want to access products across all store views
 
 ### Multi-Store Configuration
@@ -97,9 +97,9 @@ For multi-store Magento installations, you can specify a specific store code:
 
 ### Usage Examples
 
-- **Single Store:** Leave as default (`/all`) or use `/default`
-- **Multi-Store English:** Use `/en` to access only English store products
-- **Multi-Store French:** Use `/fr` to access only French store products
+- **Single Store:** Leave as default (`all`) or use `default`
+- **Multi-Store English:** Use `en` to access only English store products
+- **Multi-Store French:** Use `fr` to access only French store products
 
 > **Note:** The store code affects all API requests, including product retrieval, stock information, and sync operations. Make sure to use the appropriate store code for your use case.
 
@@ -118,7 +118,7 @@ Retrieve products from your Magento catalog using flexible search criteria.
 **Filter by Price:**
 
 ```json
-[{ "field": "price", "condition": "gt", "value": "100" }]
+[{ "field": "price", "condition": "gt", "value": 100 }]
 ```
 
 **Filter by SKU:**
@@ -187,7 +187,7 @@ Automatically sync products from Magento to a Botpress table with intelligent sc
 | `table_name`                     | String  | Yes      | Name of the Botpress table to sync products to                |
 | `custom_columns_to_add_to_table` | String  | No       | Comma-separated list of custom product attributes             |
 | `filters_json`                   | String  | No       | JSON array of filter objects for selective syncing            |
-| `retreive_reviews`               | Boolean | No       | Whether to fetch and include product reviews (default: false) |
+| `retrieve_reviews`               | Boolean | No       | Whether to fetch and include product reviews (default: false) |
 
 #### **Webhook Continuation Setup**
 
@@ -210,8 +210,8 @@ The integration automatically creates a table with the following columns:
 | `thumbnail_url`  | text    | Thumbnail image URL                                                  |
 | `stock_qty`      | number  | Quantity in stock                                                    |
 | `is_in_stock`    | boolean | Whether the product is in stock                                      |
-| `average_rating` | number  | Average review rating (only populated if `retreive_reviews` is true) |
-| `review_count`   | number  | Number of reviews (only populated if `retreive_reviews` is true)     |
+| `average_rating` | number  | Average review rating (only populated if `retrieve_reviews` is true) |
+| `review_count`   | number  | Number of reviews (only populated if `retrieve_reviews` is true)     |
 
 #### **Usage Examples**
 
@@ -228,14 +228,14 @@ The integration automatically creates a table with the following columns:
 
 - **Table Name:** magento_products
 - **Custom Columns to Add to Table:** color,tent_type
-- **Filters JSON:** [{"field": "price", "condition": "gt", "value": "50"}]
+- **Filters JSON:** [{"field": "price", "condition": "gt", "value": 50}]
 
 **With Reviews Enabled:**
 
 - **Table Name:** magento_products
 - **Custom Columns to Add to Table:** color,brand
 - **Retrieve Reviews:** true
-- **Filters JSON:** [{"field": "price", "condition": "gt", "value": "100"}]
+- **Filters JSON:** [{"field": "price", "condition": "gt", "value": 100}]
 
 #### **Output**
 
@@ -259,20 +259,20 @@ When using `filters_json` in the sync action, you can use the following conditio
 | Condition | Description                                   | Example                                                          |
 | --------- | --------------------------------------------- | ---------------------------------------------------------------- |
 | `eq`      | Equals                                        | `{"field": "sku", "condition": "eq", "value": "24-MB01"}`        |
-| `neq`     | Not equal                                     | `{"field": "price", "condition": "neq", "value": "0"}`           |
-| `gt`      | Greater than                                  | `{"field": "price", "condition": "gt", "value": "100"}`          |
-| `gteq`    | Greater than or equal                         | `{"field": "price", "condition": "gteq", "value": "50"}`         |
-| `lt`      | Less than                                     | `{"field": "price", "condition": "lt", "value": "200"}`          |
-| `lteq`    | Less than or equal                            | `{"field": "price", "condition": "lteq", "value": "150"}`        |
-| `from`    | Beginning of a range (must be used with `to`) | `{"field": "price", "condition": "from", "value": "50"}`         |
-| `to`      | End of a range (must be used with `from`)     | `{"field": "price", "condition": "to", "value": "200"}`          |
+| `neq`     | Not equal                                     | `{"field": "price", "condition": "neq", "value": 0}`             |
+| `gt`      | Greater than                                  | `{"field": "price", "condition": "gt", "value": 100}`            |
+| `gteq`    | Greater than or equal                         | `{"field": "price", "condition": "gteq", "value": 50}`           |
+| `lt`      | Less than                                     | `{"field": "price", "condition": "lt", "value": 200}`            |
+| `lteq`    | Less than or equal                            | `{"field": "price", "condition": "lteq", "value": 150}`          |
+| `from`    | Beginning of a range (must be used with `to`) | `{"field": "price", "condition": "from", "value": 50}`           |
+| `to`      | End of a range (must be used with `from`)     | `{"field": "price", "condition": "to", "value": 200}`            |
 | `like`    | Like (supports SQL wildcard characters)       | `{"field": "name", "condition": "like", "value": "jacket"}`      |
 | `nlike`   | Not like                                      | `{"field": "name", "condition": "nlike", "value": "test"}`       |
 | `in`      | In (comma-separated list of values)           | `{"field": "sku", "condition": "in", "value": "SKU1,SKU2,SKU3"}` |
 | `nin`     | Not in (comma-separated list of values)       | `{"field": "sku", "condition": "nin", "value": "SKU1,SKU2"}`     |
 | `finset`  | A value within a set of values                | `{"field": "category_id", "condition": "finset", "value": "5"}`  |
 | `nfinset` | A value that is not within a set of values    | `{"field": "category_id", "condition": "nfinset", "value": "5"}` |
-| `moreq`   | More or equal                                 | `{"field": "price", "condition": "moreq", "value": "100"}`       |
+| `moreq`   | More or equal                                 | `{"field": "price", "condition": "moreq", "value": 100}`         |
 | `null`    | Is null                                       | `{"field": "description", "condition": "null"}`                  |
 | `notnull` | Not null                                      | `{"field": "color", "condition": "notnull"}`                     |
 
@@ -288,8 +288,8 @@ magentoProducts
 
 **Filters JSON:**
 [
-{ "field": "price", "condition": "gteq", "value": "50" },
-{ "field": "price", "condition": "lteq", "value": "200" }
+{ "field": "price", "condition": "gteq", "value": 50 },
+{ "field": "price", "condition": "lteq", "value": "200 }
 ]
 
 ---
@@ -331,8 +331,8 @@ magentoProducts
 
 ```json
 [
-  { "field": "price", "condition": "gteq", "value": "50" },
-  { "field": "price", "condition": "lteq", "value": "200" },
+  { "field": "price", "condition": "gteq", "value": 50 },
+  { "field": "price", "condition": "lteq", "value": 200 },
   { "field": "status", "condition": "eq", "value": "1" }
 ]
 ```
@@ -352,8 +352,8 @@ magentoProducts
 [
   { "field": "sku", "condition": "like", "value": "WSH%" },
   { "field": "sku", "condition": "like", "value": "WP%" },
-  { "field": "price", "condition": "from", "value": "40" },
-  { "field": "price", "condition": "to", "value": "49.99" }
+  { "field": "price", "condition": "from", "value": 40 },
+  { "field": "price", "condition": "to", "value": 49.99 }
 ]
 ```
 

--- a/integrations/magento2/hub.md
+++ b/integrations/magento2/hub.md
@@ -56,12 +56,52 @@ This Botpress integration allows seamless interaction with **Magento 2 (Adobe Co
 2. Find and enable the **Magento 2** integration
 3. Enter the following configuration:
    - **Magento Domain URL** (e.g., `www.yourstore.com`)
+   - **Store Code** (optional, defaults to `/all` - see Store Code section below)
    - **Consumer Key**
    - **Consumer Secret**
    - **Access Token**
    - **Access Token Secret**
    - **Botpress Personal Access Token (PAT)** for Tables API access
 4. Click **Save Configuration**
+
+> **Note:** The integration will automatically detect your store's base currency during the first sync operation. No additional currency configuration is required.
+
+---
+
+## Store Code Configuration
+
+The **Store Code** parameter allows you to specify which Magento store view to use for API requests. This is particularly useful for multi-store Magento installations.
+
+### Default Behavior
+
+- **Default Value:** `/all` (accesses all store views)
+- **When to use:** Single-store installations or when you want to access products across all store views
+
+### Multi-Store Configuration
+
+For multi-store Magento installations, you can specify a specific store code:
+
+- **Store Code Examples:**
+  - `/default` - Default store view
+  - `/en` - English store view
+  - `/fr` - French store view
+  - `/de` - German store view
+  - `/us` - US store view
+
+### How to Find Your Store Code
+
+1. In your **Magento Admin Panel**, navigate to **Stores > All Stores**
+2. Click on the **Store View** tab
+3. The **Code** column shows the store codes available for your installation
+4. Use the code with a leading slash (e.g., `/en` for the English store view)
+
+### Usage Examples
+
+- **Single Store:** Leave as default (`/all`) or use `/default`
+- **Multi-Store English:** Use `/en` to access only English store products
+- **Multi-Store French:** Use `/fr` to access only French store products
+
+> **Note:** The store code affects all API requests, including product retrieval, stock information, and sync operations. Make sure to use the appropriate store code for your use case.
 
 ---
 

--- a/integrations/magento2/integration.definition.ts
+++ b/integrations/magento2/integration.definition.ts
@@ -3,12 +3,13 @@ import { integrationName } from './package.json'
 
 export default new IntegrationDefinition({
   name: integrationName,
-  version: '1.0.5',
+  version: '1.0.6',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {
     schema: z.object({
       magento_domain: z.string().describe('The domain of the Magento instance (example www.test-domain.com)'),
+      store_code: z.string().optional().default('/all').describe('The store code to use for the request, default is /all'),
       consumer_key: z.string().describe('The OAuth Consumer Key'),
       consumer_secret: z.string().describe('The OAuth Consumer Secret'),
       access_token: z.string().describe('The OAuth Access Token'),

--- a/integrations/magento2/integration.definition.ts
+++ b/integrations/magento2/integration.definition.ts
@@ -3,7 +3,7 @@ import { integrationName } from './package.json'
 
 export default new IntegrationDefinition({
   name: integrationName,
-  version: '1.0.0',
+  version: '1.0.5',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {
@@ -58,16 +58,18 @@ export default new IntegrationDefinition({
       input: {
         schema: z.object({
           table_name: z.string().describe('Name of the Botpress table to sync products to (will be created automatically if it doesn\'t exist)'),
-          custom_attributes: z.string().optional().describe('Comma-separated list of custom product attributes to sync (e.g., "color,tent_outer_material,tent_type")'),
+          custom_columns_to_add_to_table: z.string().optional().describe('Comma-separated list of custom product attributes to sync (e.g., "color,tent_outer_material,tent_type")'),
           filters_json: z.string().optional().describe('JSON array of filter objects, e.g. [{"field": "price", "condition": "gt", "value": "100"}]'),
-          _currentPage: z.number().optional().describe('Current page number'),
-          _totalCount: z.number().optional().describe('Total number of products'),
-          _tableId: z.string().optional().describe('ID of the Botpress table'),
-          _runId: z.string().optional().describe('Sync run ID'),
-          _customAttributeCodes: z.array(z.string()).optional().describe('Custom attribute codes'),
-          _attributeMappings: z.string().optional().describe('Attribute mappings as a JSON string'),
-          _filterCriteria: z.string().optional().describe('Filter criteria string'),
-          _currentPageProductIndex: z.number().optional().describe('Current product index within the page'),
+          retreive_reviews: z.boolean().optional().describe('Whether to retrieve reviews from Magento. To retrieve reviews, you must install the Reviews API module.'),
+          // Recursive inputs for webhook continuation
+          _currentPage: z.number().optional().describe('Current page number (used internally for webhook continuation)'),
+          _totalCount: z.number().optional().describe('Total number of products (used internally for webhook continuation)'),
+          _tableId: z.string().optional().describe('ID of the Botpress table (used internally for webhook continuation)'),
+          _runId: z.string().optional().describe('Sync run ID (used internally for webhook continuation)'),
+          _customAttributeCodes: z.array(z.string()).optional().describe('Custom attribute codes (used internally for webhook continuation)'),
+          _attributeMappings: z.string().optional().describe('Attribute mappings as a JSON string (used internally for webhook continuation)'),
+          _filterCriteria: z.string().optional().describe('Filter criteria string (used internally for webhook continuation)'),
+          _currentPageProductIndex: z.number().optional().describe('Current product index within the page (used internally for webhook continuation)'),
         }),
       },
       output: {
@@ -88,8 +90,9 @@ export default new IntegrationDefinition({
       description: 'Triggered to continue syncing products from Magento in batches',
       schema: z.object({
         table_name: z.string().describe('Name of the Botpress table to sync products to'),
-        custom_attributes: z.string().optional().describe('Comma-separated list of custom product attributes to sync'),
+        custom_columns_to_add_to_table: z.string().optional().describe('Comma-separated list of custom product attributes to sync'),
         filters_json: z.string().optional().describe('JSON array of filter objects'),
+        retreive_reviews: z.boolean().optional().describe('Whether to retrieve reviews from Magento'),
         _currentPage: z.number().optional().describe('Current page number'),
         _totalCount: z.number().optional().describe('Total number of products'),
         _tableId: z.string().optional().describe('ID of the Botpress table'),

--- a/integrations/magento2/integration.definition.ts
+++ b/integrations/magento2/integration.definition.ts
@@ -61,15 +61,6 @@ export default new IntegrationDefinition({
           custom_columns_to_add_to_table: z.string().optional().describe('Comma-separated list of custom product attributes to sync (e.g., "color,tent_outer_material,tent_type")'),
           filters_json: z.string().optional().describe('JSON array of filter objects, e.g. [{"field": "price", "condition": "gt", "value": "100"}]'),
           retreive_reviews: z.boolean().optional().describe('Whether to retrieve reviews from Magento. To retrieve reviews, you must install the Reviews API module.'),
-          // Recursive inputs for webhook continuation
-          _currentPage: z.number().optional().describe('Current page number (used internally for webhook continuation)'),
-          _totalCount: z.number().optional().describe('Total number of products (used internally for webhook continuation)'),
-          _tableId: z.string().optional().describe('ID of the Botpress table (used internally for webhook continuation)'),
-          _runId: z.string().optional().describe('Sync run ID (used internally for webhook continuation)'),
-          _customAttributeCodes: z.array(z.string()).optional().describe('Custom attribute codes (used internally for webhook continuation)'),
-          _attributeMappings: z.string().optional().describe('Attribute mappings as a JSON string (used internally for webhook continuation)'),
-          _filterCriteria: z.string().optional().describe('Filter criteria string (used internally for webhook continuation)'),
-          _currentPageProductIndex: z.number().optional().describe('Current product index within the page (used internally for webhook continuation)'),
         }),
       },
       output: {
@@ -84,24 +75,5 @@ export default new IntegrationDefinition({
       },
     },
   },
-  events: {
-    magentoSyncContinue: {
-      title: 'Magento Sync Continue',
-      description: 'Triggered to continue syncing products from Magento in batches',
-      schema: z.object({
-        table_name: z.string().describe('Name of the Botpress table to sync products to'),
-        custom_columns_to_add_to_table: z.string().optional().describe('Comma-separated list of custom product attributes to sync'),
-        filters_json: z.string().optional().describe('JSON array of filter objects'),
-        retreive_reviews: z.boolean().optional().describe('Whether to retrieve reviews from Magento'),
-        _currentPage: z.number().optional().describe('Current page number'),
-        _totalCount: z.number().optional().describe('Total number of products'),
-        _tableId: z.string().optional().describe('ID of the Botpress table'),
-        _runId: z.string().optional().describe('Sync run ID'),
-        _customAttributeCodes: z.array(z.string()).optional().describe('Custom attribute codes'),
-        _attributeMappings: z.string().optional().describe('Attribute mappings as a JSON string'),
-        _filterCriteria: z.string().optional().describe('Filter criteria string'),
-        _currentPageProductIndex: z.number().optional().describe('Current product index within the page'),
-      }),
-    },
-  },
+  events: {},
 })

--- a/integrations/magento2/integration.definition.ts
+++ b/integrations/magento2/integration.definition.ts
@@ -9,7 +9,7 @@ export default new IntegrationDefinition({
   configuration: {
     schema: z.object({
       magento_domain: z.string().describe('The domain of the Magento instance (example www.test-domain.com)'),
-      store_code: z.string().optional().default('/all').describe('The store code to use for the request, default is /all'),
+      store_code: z.string().optional().default('all').describe('The store code to use for the request, default is all'),
       consumer_key: z.string().describe('The OAuth Consumer Key'),
       consumer_secret: z.string().describe('The OAuth Consumer Secret'),
       access_token: z.string().describe('The OAuth Access Token'),
@@ -61,7 +61,7 @@ export default new IntegrationDefinition({
           table_name: z.string().describe('Name of the Botpress table to sync products to (will be created automatically if it doesn\'t exist)'),
           custom_columns_to_add_to_table: z.string().optional().describe('Comma-separated list of custom product attributes to sync (e.g., "color,tent_outer_material,tent_type")'),
           filters_json: z.string().optional().describe('JSON array of filter objects, e.g. [{"field": "price", "condition": "gt", "value": "100"}]'),
-          retreive_reviews: z.boolean().optional().describe('Whether to retrieve reviews from Magento. To retrieve reviews, you must install the Reviews API module.'),
+          retrieve_reviews: z.boolean().optional().describe('Whether to retrieve reviews from Magento. To retrieve reviews, you must install the Reviews API module.'),
         }),
       },
       output: {

--- a/integrations/magento2/package.json
+++ b/integrations/magento2/package.json
@@ -11,13 +11,13 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.15.0",
-    "@botpress/sdk": "4.9.0",
+    "@botpress/sdk": "4.15.2",
     "oauth-1.0a": "^2.2.6",
     "axios": "^1.7.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@botpress/cli": "4.8.8",
+    "@botpress/cli": "4.17.2",
     "@types/node": "^18.19.67",
     "typescript": "^5.6.3"
   }

--- a/integrations/magento2/src/actions/getProducts.ts
+++ b/integrations/magento2/src/actions/getProducts.ts
@@ -92,7 +92,7 @@ export const getProducts: bp.IntegrationProps['actions']['getProducts'] = async 
   }
 
   const searchCriteriaString = filterCriteria;
-  const url = `https://${magento_domain}/rest${store_code}/V1/products?${searchCriteriaString}`;
+  const url = `https://${magento_domain}/rest/${store_code}/V1/products?${searchCriteriaString}`;
 
   logger.forBot().info(`Constructed API URL: ${url}`)
 

--- a/integrations/magento2/src/actions/getProducts.ts
+++ b/integrations/magento2/src/actions/getProducts.ts
@@ -92,7 +92,7 @@ export const getProducts: bp.IntegrationProps['actions']['getProducts'] = async 
   }
 
   const searchCriteriaString = filterCriteria;
-  const url = `https://${magento_domain}/rest/default/V1/products?${searchCriteriaString}`;
+  const url = `https://${magento_domain}/rest/all/V1/products?${searchCriteriaString}`;
 
   logger.forBot().info(`Constructed API URL: ${url}`)
 

--- a/integrations/magento2/src/actions/getProducts.ts
+++ b/integrations/magento2/src/actions/getProducts.ts
@@ -7,7 +7,7 @@ import { ProductListSchema } from '../misc/zod-schemas'
 export const getProducts: bp.IntegrationProps['actions']['getProducts'] = async ({ ctx, input, logger }) => {
   logger.forBot().info(`Input received: ${JSON.stringify(input)}`)
 
-  const { magento_domain, consumer_key, consumer_secret, access_token, access_token_secret, user_agent } =
+  const { magento_domain, consumer_key, consumer_secret, access_token, access_token_secret, user_agent, store_code } =
     ctx.configuration
 
   logger.forBot().info(`Magento domain: ${magento_domain}`)
@@ -92,7 +92,7 @@ export const getProducts: bp.IntegrationProps['actions']['getProducts'] = async 
   }
 
   const searchCriteriaString = filterCriteria;
-  const url = `https://${magento_domain}/rest/all/V1/products?${searchCriteriaString}`;
+  const url = `https://${magento_domain}/rest${store_code}/V1/products?${searchCriteriaString}`;
 
   logger.forBot().info(`Constructed API URL: ${url}`)
 

--- a/integrations/magento2/src/actions/getStockItem.ts
+++ b/integrations/magento2/src/actions/getStockItem.ts
@@ -5,7 +5,7 @@ import * as bp from '.botpress'
 import { StockItemSchema } from '../misc/zod-schemas'
 
 export const getStockItem: bp.IntegrationProps['actions']['getStockItem'] = async ({ ctx, input, logger }) => {
-  const { magento_domain, consumer_key, consumer_secret, access_token, access_token_secret, user_agent } =
+  const { magento_domain, consumer_key, consumer_secret, access_token, access_token_secret, user_agent, store_code } =
     ctx.configuration
 
   const oauth = new OAuth({
@@ -24,7 +24,7 @@ export const getStockItem: bp.IntegrationProps['actions']['getStockItem'] = asyn
     secret: access_token_secret,
   }
 
-  const url = `https://${magento_domain}/rest/all/V1/stockItems/${encodeURIComponent(input.sku)}`
+  const url = `https://${magento_domain}/rest${store_code}/V1/stockItems/${encodeURIComponent(input.sku)}`
 
   const requestData = {
     url,

--- a/integrations/magento2/src/actions/getStockItem.ts
+++ b/integrations/magento2/src/actions/getStockItem.ts
@@ -24,7 +24,7 @@ export const getStockItem: bp.IntegrationProps['actions']['getStockItem'] = asyn
     secret: access_token_secret,
   }
 
-  const url = `https://${magento_domain}/rest${store_code}/V1/stockItems/${encodeURIComponent(input.sku)}`
+  const url = `https://${magento_domain}/rest/${store_code}/V1/stockItems/${encodeURIComponent(input.sku)}`
 
   const requestData = {
     url,

--- a/integrations/magento2/src/actions/getStockItem.ts
+++ b/integrations/magento2/src/actions/getStockItem.ts
@@ -24,7 +24,7 @@ export const getStockItem: bp.IntegrationProps['actions']['getStockItem'] = asyn
     secret: access_token_secret,
   }
 
-  const url = `https://${magento_domain}/rest/default/V1/stockItems/${encodeURIComponent(input.sku)}`
+  const url = `https://${magento_domain}/rest/all/V1/stockItems/${encodeURIComponent(input.sku)}`
 
   const requestData = {
     url,

--- a/integrations/magento2/src/index.ts
+++ b/integrations/magento2/src/index.ts
@@ -1,5 +1,5 @@
 import * as sdk from '@botpress/sdk'
-import { getProducts, getStockItem, syncProducts, syncProductsCore } from './actions'
+import { getProducts, getStockItem, syncProducts, executeSyncProducts } from './actions'
 import * as bp from '.botpress'
 import axios from 'axios'
 import crypto from 'crypto'
@@ -29,7 +29,7 @@ export default new bp.Integration({
         secret: access_token_secret,
       }
 
-      const testUrl = `https://${magento_domain}/rest${store_code}/V1/directory/currency`
+      const testUrl = `https://${magento_domain}/rest/${store_code}/V1/directory/currency`
 
       const requestData = {
         url: testUrl,
@@ -86,7 +86,7 @@ export default new bp.Integration({
 
         try {
           const { table_name, custom_attributes, filters_json, _currentPage, _totalCount, _tableId, _runId, _customAttributeCodes, _attributeMappings, _filterCriteria, _currentPageProductIndex } = body.data
-          const result = await syncProductsCore({
+          const result = await executeSyncProducts({
             ctx,
             input: {
               table_name,

--- a/integrations/magento2/src/index.ts
+++ b/integrations/magento2/src/index.ts
@@ -10,7 +10,7 @@ export default new bp.Integration({
     logger.forBot().info('Registering Magento2 integration')
     
     try {
-      const { magento_domain, consumer_key, consumer_secret, access_token, access_token_secret, user_agent } =
+      const { magento_domain, consumer_key, consumer_secret, access_token, access_token_secret, user_agent, store_code } =
         ctx.configuration
 
       const oauth = new OAuth({
@@ -29,7 +29,7 @@ export default new bp.Integration({
         secret: access_token_secret,
       }
 
-      const testUrl = `https://${magento_domain}/rest/all/V1/directory/currency`
+      const testUrl = `https://${magento_domain}/rest${store_code}/V1/directory/currency`
 
       const requestData = {
         url: testUrl,


### PR DESCRIPTION
Main Feature
Revamp the behavior of the _**Sync Products to Botpress Table**_ card:
	•	Remove event creation and manual sync configuration.
	•	Implement background syncing via webhooks when the process takes too long.

Refactorings
	•	Add the possibility for the user to use the store code he wants, default is **_/all_**
	•	Rename field “Custom Attributes” to “Custom Columns to Add to the Table” for better clarity.
	•	Simplify the **_Sync Products to Botpress Table_** card by removing unnecessary fields.