### PR TITLE
Add an option to ignore livechat convos not started by botpress HITL

### DIFF
--- a/integrations/livechat-hitl/integration.definition.ts
+++ b/integrations/livechat-hitl/integration.definition.ts
@@ -12,7 +12,7 @@ import {
 export default new IntegrationDefinition({
   name: integrationName,
   title: "LiveChat HITL",
-  version: "2.0.1",
+  version: "2.0.2",
   icon: "icon.svg",
   description:
     "This integration allows your bot to use LiveChat as a HITL provider. Messages will appear in LiveChat.",

--- a/integrations/livechat-hitl/src/definitions/schemas.ts
+++ b/integrations/livechat-hitl/src/definitions/schemas.ts
@@ -13,6 +13,11 @@ export const LiveChatConfigurationSchema = z.object({
   groupId: z
     .number()
     .describe("LiveChat Group ID for HITL conversations and chat transfers"),
+  ignoreNonHitlConversations: z
+    .boolean()
+    .optional()
+    .title("Ignore non-HITL conversations")
+    .describe("Ignore conversations that were not created by the startHitl action"),
 });
 
 export type LiveChatConfiguration = z.infer<typeof LiveChatConfigurationSchema>;

--- a/integrations/livechat-hitl/src/events/chatDeactivated.ts
+++ b/integrations/livechat-hitl/src/events/chatDeactivated.ts
@@ -8,6 +8,7 @@ export const handleChatDeactivated = async (
   >,
   logger: bp.Logger,
   client: bp.Client,
+  conversation: any,
 ): Promise<void> => {
   const { chat_id, thread_id, user_id } = webhookPayload.payload;
 
@@ -15,13 +16,6 @@ export const handleChatDeactivated = async (
     chat_id,
     thread_id,
     user_id,
-  });
-
-  const { conversation } = await client.getOrCreateConversation({
-    channel: "hitl",
-    tags: {
-      id: chat_id,
-    },
   });
 
   await client.createEvent({

--- a/integrations/livechat-hitl/src/events/chatTransferred.ts
+++ b/integrations/livechat-hitl/src/events/chatTransferred.ts
@@ -8,6 +8,7 @@ export const handleChatTransferred = async (
   >,
   logger: bp.Logger,
   client: bp.Client,
+  conversation: any,
 ): Promise<void> => {
   const { chat_id, thread_id, requester_id, reason, transferred_to } =
     webhookPayload.payload;
@@ -20,13 +21,6 @@ export const handleChatTransferred = async (
     transferred_to: {
       group_ids: transferred_to.group_ids || [],
       agent_ids: transferred_to.agent_ids,
-    },
-  });
-
-  const { conversation } = await client.getOrCreateConversation({
-    channel: "hitl",
-    tags: {
-      id: chat_id,
     },
   });
 

--- a/integrations/livechat-hitl/src/events/incomingMessage.ts
+++ b/integrations/livechat-hitl/src/events/incomingMessage.ts
@@ -5,6 +5,7 @@ export const handleIncomingMessage = async (
   webhookPayload: Extract<LiveChatWebhookPayload, { action: "incoming_event" }>,
   logger: bp.Logger,
   client: bp.Client,
+  conversation: any,
 ): Promise<void> => {
   const { chat_id, thread_id, event } = webhookPayload.payload;
   const { author_id, text, type, custom_id, created_at, visibility } = event;
@@ -34,13 +35,6 @@ export const handleIncomingMessage = async (
   const { user: agentUser } = await client.getOrCreateUser({
     tags: {
       agentId: author_id,
-    },
-  });
-
-  const { conversation } = await client.getOrCreateConversation({
-    channel: "hitl",
-    tags: {
-      id: chat_id,
     },
   });
 


### PR DESCRIPTION
This will prevent conversations started outside of botpress hitl from showing up in the conversations tab in the botpress bot dashboard. 