### PR TITLE
fix: update exclusion list to include newly added integrations

### DIFF
--- a/.github/workflows/check-integration-naming.yml
+++ b/.github/workflows/check-integration-naming.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Create integration validation script
         run: |
           cat > ./validate-integration-plus-prefix.js << 'EOF'
@@ -16,7 +16,10 @@ jobs:
           const path = require('path');
 
           const EXCLUDED_INTEGRATIONS = [
-            'hitl-salesforce'
+            'hitl-salesforce',
+            'klaviyo',
+            'mailerlite',
+            'pipedrive',
           ];
 
           const NAME_REGEX = /name:\s*['"]([^'"]+)['"]/;
@@ -89,9 +92,9 @@ jobs:
           const integrationsDir = './integrations';
           const integrationDirs = fs.readdirSync(integrationsDir)
             .filter(file => fs.statSync(path.join(integrationsDir, file)).isDirectory());
-          
+
           let validationFailed = false;
-          
+
           integrationDirs.forEach(integration => {
             if (EXCLUDED_INTEGRATIONS.includes(integration)) {
               console.log(`⏭️  Skipping validation for ${integration} (excluded)`);
@@ -109,13 +112,13 @@ jobs:
               console.log(`✅ Integration ${integration} passed validation`);
             }
           });
-          
+
           if (validationFailed) {
             process.exit(1);
           }
           EOF
-          
+
           chmod +x ./validate-integration-plus-prefix.js
-      
+
       - name: Check all integrations
         run: node ./validate-integration-plus-prefix.js


### PR DESCRIPTION
## Purpose
Newly launched integrations (in botpress/growth) have no plus/ prefix, which causes them to fail github actions. This PR adds them to a list of exclusions