### PR TITLE
changing version and integration names

### DIFF
--- a/integrations/mailerlite/integration.definition.ts
+++ b/integrations/mailerlite/integration.definition.ts
@@ -1,30 +1,30 @@
-import { IntegrationDefinition, z } from "@botpress/sdk";
-import { actions, events, states } from "definitions";
-import { integrationName } from "./package.json";
+import { IntegrationDefinition, z } from '@botpress/sdk';
+import { actions, events, states } from 'definitions';
+import { integrationName } from './package.json';
 
 export default new IntegrationDefinition({
-  name: integrationName,
-  title: "MailerLite",
-  description:
-    "Connect with MailerLite to manage subscribers, groups, and email campaigns",
-  version: "1.0.0",
-  readme: "hub.md",
-  icon: "icon.svg",
+	name: integrationName,
+	title: 'MailerLite',
+	description:
+		'Connect with MailerLite to manage subscribers, groups, and email campaigns',
+	version: '3.0.0',
+	readme: 'hub.md',
+	icon: 'icon.svg',
 
-  configuration: {
-    schema: z
-      .object({
-        APIKey: z
-          .string()
-          .title("API Key")
-          .describe("Developer API token")
-          .min(1)
-          .secret(),
-      })
-      .required(),
-  },
+	configuration: {
+		schema: z
+			.object({
+				APIKey: z
+					.string()
+					.title('API Key')
+					.describe('Developer API token')
+					.min(1)
+					.secret(),
+			})
+			.required(),
+	},
 
-  actions,
-  events,
-  states,
+	actions,
+	events,
+	states,
 });

--- a/integrations/mailerlite/package.json
+++ b/integrations/mailerlite/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@bp-templates/mailerlite",
-  "integrationName": "plus/mailerlite",
-  "scripts": {
-    "build": "bp add -y && bp build",
-    "check:type": "tsc --noEmit",
-    "check:bplint": "bp lint"
-  },
-  "private": true,
-  "dependencies": {
-    "@botpress/client": "1.24.1",
-    "@botpress/sdk": "4.15.6",
-    "@mailerlite/mailerlite-nodejs": "^1.4.1"
-  },
-  "devDependencies": {
-    "@types/node": "^22.16.4",
-    "typescript": "^5.6.3"
-  }
+	"name": "@bp-templates/mailerlite",
+	"integrationName": "mailerlite",
+	"scripts": {
+		"build": "bp add -y && bp build",
+		"check:type": "tsc --noEmit",
+		"check:bplint": "bp lint"
+	},
+	"private": true,
+	"dependencies": {
+		"@botpress/client": "1.24.1",
+		"@botpress/sdk": "4.15.6",
+		"@mailerlite/mailerlite-nodejs": "^1.4.1"
+	},
+	"devDependencies": {
+		"@types/node": "^22.16.4",
+		"typescript": "^5.6.3"
+	}
 }


### PR DESCRIPTION
changing version and integration names so we can push through botpress/botpress and overwrite the existing dummy