### PR TITLE
fix: remove unused error variable from subscriber action

### DIFF
--- a/integrations/mailerlite/src/actions/subscriber.ts
+++ b/integrations/mailerlite/src/actions/subscriber.ts
@@ -31,7 +31,7 @@ export const fetchSubscriber: bp.Integration['actions']['fetchSubscriber'] =
 		try {
 			const response = await mlClient.subscribers.find(searchParam);
 			return { subscriber: subscriberSchema.parse(response.data.data) };
-		} catch (error) {
+		} catch {
 			logger.forBot().debug('No subscriber found!');
 			return { subscriber: undefined };
 		}


### PR DESCRIPTION
We're never actually using the error variable here, so no need to define it. Didn't catch this until doing a second pass through