### PR TITLE
feat: add api token validation for klaviyo and mailerlite

### DIFF
--- a/integrations/klaviyo/integration.definition.ts
+++ b/integrations/klaviyo/integration.definition.ts
@@ -6,7 +6,7 @@ export default new IntegrationDefinition({
   title: "Klaviyo",
   description:
     "Manage customer profiles, generate leads, and curate marketing campaigns",
-  version: "3.0.0",
+  version: "3.0.1",
   readme: "hub.md",
   icon: "icon.svg",
   configuration: {

--- a/integrations/klaviyo/src/setup.ts
+++ b/integrations/klaviyo/src/setup.ts
@@ -1,12 +1,18 @@
 import { RuntimeError } from "@botpress/sdk";
 import * as bp from ".botpress";
+import { getProfilesApi } from './auth';
 
-export const register: bp.IntegrationProps["register"] = async ({ ctx }) => {
-  const { apiKey } = ctx.configuration;
-
-  if (!apiKey) {
-    throw new RuntimeError("API Key is required for manual configuration");
+export const register: bp.IntegrationProps["register"] = async ({ ctx, logger }) => {
+  try {
+    const profilesApi = getProfilesApi(ctx);
+    await profilesApi.getProfiles({ pageSize: 1 })
+    logger.forBot().info("Klaviyo integration registered successfully")
+  } catch (error) {
+    logger.forBot().error("Failed to register Klaviyo integration", error)
+    throw new RuntimeError("Failed to register Klaviyo integration")
   }
 };
 
-export const unregister: bp.IntegrationProps["unregister"] = async () => {};
+export const unregister: bp.IntegrationProps["unregister"] = async ({ logger }) => {
+  logger.forBot().info("Klaviyo integration unregistered")
+};

--- a/integrations/mailerlite/integration.definition.ts
+++ b/integrations/mailerlite/integration.definition.ts
@@ -7,7 +7,7 @@ export default new IntegrationDefinition({
   title: "MailerLite",
   description:
     "Connect with MailerLite to manage subscribers, groups, and email campaigns",
-  version: "3.0.0",
+  version: "3.0.1",
   readme: "hub.md",
   icon: "icon.svg",
 

--- a/integrations/mailerlite/src/setup/register.ts
+++ b/integrations/mailerlite/src/setup/register.ts
@@ -1,5 +1,6 @@
 import { getAuthenticatedMailerLiteClient } from 'src/client';
 import * as bp from '.botpress';
+import { RuntimeError } from '@botpress/client';
 
 export const register: bp.IntegrationProps['register'] = async ({
 	ctx,
@@ -8,7 +9,13 @@ export const register: bp.IntegrationProps['register'] = async ({
 	logger,
 }) => {
 	const mlClient = await getAuthenticatedMailerLiteClient({ ctx, client });
-
+	try {
+		await mlClient.subscribers.get({ limit: 1});
+		logger.forBot().info("MailerLite integration registered successfully")
+	} catch (error) {
+		logger.forBot().error("Failed to register MailerLite integration", error)
+		throw new RuntimeError("Failed to register MailerLite integration")
+	}
 	const params = {
 		name: 'Webhook',
 		events: ['subscriber.created'],


### PR DESCRIPTION
## Purpose
We want to add validation and log errors when a key is incorrect. We do not need a success state, but errors should surface as exceptions.
## Proof
### Mailerlite
Before | After
-|-
<video src="https://github.com/user-attachments/assets/f3fe4ffd-b8d3-4e72-8f83-069a524ef3ba" /> | <video src="https://github.com/user-attachments/assets/5cb2de10-5f8b-47e7-8fee-9215d0efddfd" />

### Klaviyo
Before | After
-|-
<video src="https://github.com/user-attachments/assets/9a3c250d-489d-414a-8ca3-7a83f711b3af" /> | <video src="https://github.com/user-attachments/assets/38d8be22-11c1-432a-b83e-1ee25e47cf2e" />