### PR TITLE
Refactor: Consolidate integration naming to single source of truth

### DIFF
--- a/integrations/brevo-hitl/package.json
+++ b/integrations/brevo-hitl/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/empty-integration",
-  "integrationName": "plus/brevo-hitl",
   "scripts": {
     "check:type": "tsc --noEmit",
     "version": "bp --version",

--- a/integrations/gohighlevel/integration.definition.ts
+++ b/integrations/gohighlevel/integration.definition.ts
@@ -1,5 +1,4 @@
 import { IntegrationDefinition, z } from '@botpress/sdk'
-import { integrationName } from './package.json'
 
 import {
   createContactInputSchema,
@@ -45,7 +44,7 @@ import {
 } from './src/misc/custom-schemas'
 
 export default new IntegrationDefinition({
-  name: integrationName ?? 'go-high-level',
+  name: 'plus/go-high-level',
   version: '1.0.3',
   title: 'GoHighLevel',
   readme: 'hub.md',

--- a/integrations/gohighlevel/package.json
+++ b/integrations/gohighlevel/package.json
@@ -1,6 +1,5 @@
 {
   "name": "go_high_level",
-  "integrationName": "plus/go-high-level",
   "scripts": {
     "version": "bp --version",
     "login": "bp login",

--- a/integrations/google-chat-spaces/integration.definition.ts
+++ b/integrations/google-chat-spaces/integration.definition.ts
@@ -1,8 +1,7 @@
 import { IntegrationDefinition, z } from '@botpress/sdk'
-import { integrationName } from './package.json'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/google-chat-spaces',
   title: 'Google Chat Spaces',
   version: '1.0.2',
   readme: 'hub.md',

--- a/integrations/google-chat-spaces/package.json
+++ b/integrations/google-chat-spaces/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/empty-integration",
-  "integrationName": "plus/google-chat-spaces",
   "scripts": {
     "version": "bp --version",
     "login": "bp login",

--- a/integrations/google-sheets/integration.definition.ts
+++ b/integrations/google-sheets/integration.definition.ts
@@ -1,9 +1,8 @@
 import { IntegrationDefinition } from '@botpress/sdk'
-import { integrationName } from './package.json'
 import { configuration, actions, events, states } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/google-sheets',
   version: '1.2.4',
   title: 'Google Sheets Public Sync',
   readme: 'hub.md',

--- a/integrations/google-sheets/package.json
+++ b/integrations/google-sheets/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-integrations/google-sheets",
-  "integrationName": "plus/google-sheets",
   "scripts": {
     "check:type": "tsc --noEmit"
   },

--- a/integrations/hitl-api/integration.definition.ts
+++ b/integrations/hitl-api/integration.definition.ts
@@ -1,8 +1,7 @@
 import { IntegrationDefinition, messages, interfaces, z } from '@botpress/sdk'
-import { name, integrationName } from './package.json'
 
 export default new IntegrationDefinition({
-  name: integrationName ?? name,
+  name: 'plus/hitl-api',
   version: '0.2.1',
   title: 'Human in the Loop API',
   description: 'This integration allows you to connect Botpress to a Human in the Loop / Live Agent API',

--- a/integrations/hitl-api/package.json
+++ b/integrations/hitl-api/package.json
@@ -1,6 +1,5 @@
 {
   "name": "hitl-api",
-  "integrationName": "plus/hitl-api",
   "scripts": {
     "login": "bp login",
     "start": "nodemon --watch \"./*\" --ext \"ts\" --exec \"bp deploy -y\"",

--- a/integrations/hitl-salesforce/integration.definition.ts
+++ b/integrations/hitl-salesforce/integration.definition.ts
@@ -1,5 +1,4 @@
 import { IntegrationDefinition, IntegrationDefinitionProps, z } from '@botpress/sdk'
-import { integrationName } from './package.json'
 import hitl from './bp_modules/hitl'
 import { configuration, channels, states, events, actions } from './src/definitions'
 
@@ -12,7 +11,7 @@ export const user = {
 } satisfies IntegrationDefinitionProps['user']
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'hitl-salesforce',
   title: 'SalesForce Messaging (Alpha)',
   version: '0.5.1',
   icon: 'icon.svg',

--- a/integrations/hitl-salesforce/package.json
+++ b/integrations/hitl-salesforce/package.json
@@ -1,6 +1,5 @@
 {
   "name": "hitl-salesforce",
-  "integrationName": "hitl-salesforce",
   "version": "0.0.8",
   "description": "Integration for HITL Salesforce Messaging",
   "private": true,

--- a/integrations/hubspot-help-desk-hitl/integration.definition.ts
+++ b/integrations/hubspot-help-desk-hitl/integration.definition.ts
@@ -1,10 +1,9 @@
 import { IntegrationDefinition, z } from '@botpress/sdk'
-import { integrationName } from './package.json'
 import hitl from './bp_modules/hitl'
 import { events, configuration, states, channels, user } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/hubspot-help-desk-hitl',
   title: 'HubSpot Help Desk HITL',
   version: '3.0.0',
   icon: 'icon.svg',

--- a/integrations/hubspot-help-desk-hitl/package.json
+++ b/integrations/hubspot-help-desk-hitl/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/empty-integration",
-  "integrationName": "plus/hubspot-help-desk-hitl",
   "scripts": {
     "check:type": "tsc --noEmit",
     "version": "bp --version",

--- a/integrations/hubspot-hitl/integration.definition.ts
+++ b/integrations/hubspot-hitl/integration.definition.ts
@@ -1,10 +1,9 @@
 import { IntegrationDefinition, z } from '@botpress/sdk'
-import { integrationName } from './package.json'
 import hitl from './bp_modules/hitl'
 import { events, configuration, states, channels, user } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/hubspot-hitl',
   title: 'HubSpot Inbox HITL',
   version: '5.0.2',
   icon: 'icon.svg',

--- a/integrations/hubspot-hitl/package.json
+++ b/integrations/hubspot-hitl/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/empty-integration",
-  "integrationName": "plus/hubspot-hitl",
   "type": "module",
   "scripts": {
     "check:type": "tsc --noEmit",

--- a/integrations/huggingface/integration.definition.ts
+++ b/integrations/huggingface/integration.definition.ts
@@ -1,8 +1,7 @@
 import { z, IntegrationDefinition, interfaces } from '@botpress/sdk'
-import { integrationName } from './package.json'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/huggingface',
   title: 'Hugging Face',
   version: '0.0.2',
   readme: 'hub.md',

--- a/integrations/huggingface/package.json
+++ b/integrations/huggingface/package.json
@@ -1,6 +1,5 @@
 {
   "name": "huggingface",
-  "integrationName": "plus/huggingface",
   "scripts": {
     "dev": "nodemon --watch \"./src/*\" --ext \"ts\" --exec \"bp deploy -y\"",
     "check:type": "tsc --noEmit"

--- a/integrations/intercom-hitl/integration.definition.ts
+++ b/integrations/intercom-hitl/integration.definition.ts
@@ -1,10 +1,9 @@
 import { IntegrationDefinition, z } from '@botpress/sdk'
-import { integrationName } from './package.json'
 import hitl from './bp_modules/hitl'
 import { events, configuration, states, channels, user } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/intercom-hitl',
   title: 'Intercom HITL',
   version: '2.0.0',
   icon: 'icon.svg',

--- a/integrations/intercom-hitl/package.json
+++ b/integrations/intercom-hitl/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/empty-integration",
-  "integrationName": "plus/intercom-hitl",
   "scripts": {
     "check:type": "tsc --noEmit",
     "version": "bp --version",

--- a/integrations/klaviyo/package.json
+++ b/integrations/klaviyo/package.json
@@ -1,6 +1,5 @@
 {
   "name": "klaviyo",
-  "integrationName": "plus/klaviyo",
   "scripts": {
     "check:type": "tsc --noEmit"
   },

--- a/integrations/livechat-hitl/integration.definition.ts
+++ b/integrations/livechat-hitl/integration.definition.ts
@@ -1,10 +1,9 @@
 import { IntegrationDefinition, z } from '@botpress/sdk'
-import { integrationName } from './package.json'
 import hitl from './bp_modules/hitl'
 import { events, configuration, states, channels, user } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/livechat-hitl',
   title: 'LiveChat HITL',
   version: '3.0.1',
   icon: 'icon.svg',

--- a/integrations/livechat-hitl/package.json
+++ b/integrations/livechat-hitl/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/empty-integration",
-  "integrationName": "plus/livechat-hitl",
   "scripts": {
     "check:type": "tsc --noEmit",
     "version": "bp --version",

--- a/integrations/magento2/integration.definition.ts
+++ b/integrations/magento2/integration.definition.ts
@@ -1,8 +1,7 @@
 import { z, IntegrationDefinition } from '@botpress/sdk'
-import { integrationName } from './package.json'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/magento2',
   version: '2.0.1',
   readme: 'hub.md',
   icon: 'icon.svg',

--- a/integrations/magento2/package.json
+++ b/integrations/magento2/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/hello-world",
-  "integrationName": "plus/magento2",
   "scripts": {
     "check:type": "tsc --noEmit",
     "version": "bp --version",

--- a/integrations/mailerlite/integration.definition.ts
+++ b/integrations/mailerlite/integration.definition.ts
@@ -1,9 +1,8 @@
 import { IntegrationDefinition, z } from '@botpress/sdk'
 import { actions, events, states } from 'definitions'
-import { integrationName } from './package.json'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'mailerlite',
   title: 'MailerLite',
   description: 'Connect with MailerLite to manage subscribers, groups, and email campaigns',
   version: '3.0.1',

--- a/integrations/mailerlite/package.json
+++ b/integrations/mailerlite/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/mailerlite",
-  "integrationName": "mailerlite",
   "scripts": {
     "build": "bp add -y && bp build",
     "check:type": "tsc --noEmit",

--- a/integrations/pipedrive/package.json
+++ b/integrations/pipedrive/package.json
@@ -1,6 +1,5 @@
 {
   "name": "pipedrive",
-  "integrationName": "pipedrive",
   "description": "Pipedrive integration for Botpress",
   "private": true,
   "scripts": {

--- a/integrations/salesforce/integration.definition.ts
+++ b/integrations/salesforce/integration.definition.ts
@@ -1,9 +1,8 @@
 import { IntegrationDefinition, z } from '@botpress/sdk'
-import { integrationName } from './package.json'
 import { actionDefinitions } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/salesforce',
   title: 'Salesforce',
   version: '1.0.3',
   readme: 'hub.md',

--- a/integrations/salesforce/package.json
+++ b/integrations/salesforce/package.json
@@ -1,6 +1,5 @@
 {
   "name": "salesforce",
-  "integrationName": "plus/salesforce",
   "scripts": {
     "check:type": "tsc --noEmit",
     "build": "bp build",

--- a/integrations/sharepoint-excel/integration.definition.ts
+++ b/integrations/sharepoint-excel/integration.definition.ts
@@ -1,8 +1,7 @@
 import { z, IntegrationDefinition } from '@botpress/sdk'
-import { integrationName } from './package.json'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/sharepoint-excel',
   version: '2.2.0',
   title: 'SharePoint Excel',
   description: 'Sync one or many SharePoint document libraries with one or more Botpress knowledge bases.',

--- a/integrations/sharepoint/integration.definition.ts
+++ b/integrations/sharepoint/integration.definition.ts
@@ -1,8 +1,7 @@
 import { z, IntegrationDefinition } from '@botpress/sdk'
-import { integrationName } from './package.json'
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/sharepoint',
   version: '3.0.4',
   title: 'SharePoint',
   description: 'Sync one or many SharePoint document libraries with one or more Botpress knowledge bases.',

--- a/integrations/sharepoint/package.json
+++ b/integrations/sharepoint/package.json
@@ -1,6 +1,5 @@
 {
   "name": "sharepoint",
-  "integrationName": "plus/sharepoint",
   "scripts": {
     "check:type": "tsc --noEmit",
     "start": "nodemon --watch \"./*\" --ext \"ts\" --exec \"bp deploy -y\"",

--- a/integrations/shopify-products-sync/package.json
+++ b/integrations/shopify-products-sync/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@botpresshub/shopify-products-sync",
-  "integrationName": "plus/shopify-products-sync",
   "scripts": {
     "check:type": "tsc --noEmit",
     "build": "bp add -y && bp build"

--- a/integrations/twiliovoice/integration.definition.ts
+++ b/integrations/twiliovoice/integration.definition.ts
@@ -1,8 +1,7 @@
 import { IntegrationDefinition, messages, z } from '@botpress/sdk';
-import { integrationName } from './package.json';
 
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/twiliovoice',
   title: 'Twilio Voice',
   description:
     'The Twilio Voice integration facilitates seamless voice communication between your AI-powered chatbot and Twilio',

--- a/integrations/twiliovoice/package.json
+++ b/integrations/twiliovoice/package.json
@@ -1,6 +1,5 @@
 {
   "name": "twiliovoice",
-  "integrationName": "plus/twiliovoice",
   "scripts": {
     "type:check": "tsc --noEmit",
     "dev": "nodemon --watch \"./src/*\" --ext \"ts\" --exec \"bp deploy -y\""

--- a/integrations/zoho-sales-iq-hitl/integration.definition.ts
+++ b/integrations/zoho-sales-iq-hitl/integration.definition.ts
@@ -1,9 +1,8 @@
 import { IntegrationDefinition } from '@botpress/sdk'
 import hitl from './bp_modules/hitl'
 import { events, configuration, channels, states, user } from './src/definitions'
-import { integrationName } from './package.json'
 export default new IntegrationDefinition({
-  name: integrationName,
+  name: 'plus/zoho-sales-iq-hitl',
   title: 'Zoho Sales IQ HITL',
   version: '2.0.1',
   icon: 'icon.svg',

--- a/integrations/zoho-sales-iq-hitl/package.json
+++ b/integrations/zoho-sales-iq-hitl/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bp-templates/empty-integration",
-  "integrationName": "plus/zoho-sales-iq-hitl",
   "scripts": {
     "check:type": "tsc --noEmit",
     "version": "bp --version",

--- a/integrations/zoom/package.json
+++ b/integrations/zoom/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@botpresshub/zoom",
-  "integrationName": "plus/zoom",
   "scripts": {
     "check:type": "tsc --noEmit"
   },


### PR DESCRIPTION
This PR standardizes how integration names are defined across all integrations by removing the redundant `integrationName` field from `package.json` files and ensuring all integration metadata is defined exclusively in `integration.definition.ts`.