### PR TITLE
fix: simplify deploy-integrations workflow triggering

### DIFF
--- a/.github/workflows/deploy-integrations.yml
+++ b/.github/workflows/deploy-integrations.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'integrations/**'
   workflow_dispatch:
     inputs:
       force:
@@ -20,7 +22,6 @@ jobs:
   deploy-production:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'workflow_dispatch' || contains(toJSON(github.event.head_commit.modified), 'integrations/') || contains(toJSON(github.event.head_commit.added), 'integrations/')
     steps:
       - uses: actions/checkout@v4
 

--- a/integrations/magento2/integration.definition.ts
+++ b/integrations/magento2/integration.definition.ts
@@ -2,7 +2,7 @@ import { z, IntegrationDefinition } from '@botpress/sdk'
 
 export default new IntegrationDefinition({
   name: 'plus/magento2',
-  version: '2.0.2',
+  version: '2.0.3',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to trigger when changes occur in the integrations directory, ensuring deployments run automatically when relevant updates are made.
  * Simplified deployment conditions so integration deployments proceed whenever the workflow is triggered.

* **Release**
  * Magento 2 integration version bumped from 2.0.2 to 2.0.3.

* **Documentation**
  * No user-facing documentation changes.

* **Tests**
  * No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->