### PR TITLE
feat: add salesforce to deploy-integrations exclude list

### DIFF
--- a/.github/scripts/deploy-all-integrations.sh
+++ b/.github/scripts/deploy-all-integrations.sh
@@ -25,7 +25,7 @@ export BOTPRESS_WORKSPACE_ID
 source ./.github/scripts/deploy-helpers.sh
 
 # Configuration
-EXCLUDE_INTEGRATIONS=("hitl-salesforce" "hitl-api" "huggingface")
+EXCLUDE_INTEGRATIONS=("hitl-salesforce" "hitl-api" "huggingface" "salesforce")
 
 # Make the integration-exists script executable
 chmod +x ./.github/scripts/integration-exists.sh

--- a/integrations/magento2/integration.definition.ts
+++ b/integrations/magento2/integration.definition.ts
@@ -2,7 +2,7 @@ import { z, IntegrationDefinition } from '@botpress/sdk'
 
 export default new IntegrationDefinition({
   name: 'plus/magento2',
-  version: '2.0.3',
+  version: '2.0.4',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline to exclude the Salesforce integration from automated rollouts, reducing scope during deployments.
  * Incremented the Magento 2 integration version to 2.0.4 to align with the latest release cycle.

* **Impact**
  * No user-facing functionality changes. Existing integrations continue to operate as before.
  * Deployment behavior is adjusted only for internal rollout processes; end users should not experience any service disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->