### PR TITLE
feat: prettier check workflow

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -42,13 +42,6 @@ jobs:
             exit 1
           fi
 
-      # Ensure both branches involved in the PR are present locally for comparison
-      - name: Ensure PR refs are fetched
-        run: |
-          # Make sure we have both base & head refs available for comparison
-          git fetch origin ${{ github.event.pull_request.base.ref }} || true
-          git fetch origin ${{ github.event.pull_request.head.ref }} || true
-
       - name: Get changed files
         id: changed_files
         shell: bash


### PR DESCRIPTION
## Purpose
There's been a few instances of PRs that are not properly formatted entering our repo, requiring pushes to PR branches and retroactive changes to fix formatting issue. To avoid this issue, we can add a blocking workflow that requires prettier formatting on **only the files that the author changed**

## Proof
I've deployed this on my personal repo, the only changes were migrating from npm to pnpm equivalents: https://github.com/SimonNRisk/accountability-buddy