### PR TITLE
 fix(email-notifier): accept linebreaks in plain text email body

### DIFF
--- a/integrations/email-notifier/integration.definition.ts
+++ b/integrations/email-notifier/integration.definition.ts
@@ -3,7 +3,7 @@ import { actions, events, states } from 'src/definitions/index'
 
 export default new IntegrationDefinition({
   name: 'plus/email-notifier',
-  version: '1.1.0',
+  version: '1.1.1',
   title: 'Email Notifier',
   description: 'Send emails to your Botpress bot in minutes',
   readme: 'hub.md',

--- a/integrations/email-notifier/src/actions/send-mail.ts
+++ b/integrations/email-notifier/src/actions/send-mail.ts
@@ -22,7 +22,7 @@ export const sendMail: bp.IntegrationProps['actions']['sendMail'] = async ({ inp
     </div>`
       : `<div>
     <p>${header}</p>
-    ${input.body ? `<p>${input.body}</p>` : ''}
+    ${input.body ? `<p>${input.body.replace(/\r?\n/g, '<br>')}</p>` : ''}
     ${EMAIL_SIGNATURE}
     <p><a href="{{amazonSESUnsubscribeUrl}}">Unsubscribe</a></p>
     </div>`


### PR DESCRIPTION
  ## Summary
  - Converts `\n` linebreaks to `<br>` tags when `isHtml` is false
  - Previously, plain text with linebreaks was rendered as a single block of
  text (one line)