### PR TITLE
fix(hs-helpdesk): get/create convo after user checks

### DIFF
--- a/integrations/hubspot-help-desk-hitl/integration.definition.ts
+++ b/integrations/hubspot-help-desk-hitl/integration.definition.ts
@@ -5,7 +5,7 @@ import { events, configuration, states, channels, user } from './src/definitions
 export default new IntegrationDefinition({
   name: 'plus/hubspot-help-desk-hitl',
   title: 'HubSpot Help Desk HITL',
-  version: '3.1.0',
+  version: '3.1.1',
   icon: 'icon.svg',
   description:
     'This integration allows your bot to use HubSpot as a HITL provider. Messages will appear in HubSpot Help Desk.',

--- a/integrations/hubspot-help-desk-hitl/src/events/operatorAssignedUpdate.ts
+++ b/integrations/hubspot-help-desk-hitl/src/events/operatorAssignedUpdate.ts
@@ -20,13 +20,6 @@ export const handleOperatorAssignedUpdate = async ({
     return
   }
 
-  const { conversation } = await client.getOrCreateConversation({
-    channel: 'hitl',
-    tags: {
-      id: threadInfo.id,
-    },
-  })
-
   // Try to find existing user by email first, then by phone number
   let user
   let emailUserToDelete = null
@@ -102,6 +95,13 @@ export const handleOperatorAssignedUpdate = async ({
       )
     return
   }
+
+  const { conversation } = await client.getOrCreateConversation({
+    channel: 'hitl',
+    tags: {
+      id: threadInfo.id,
+    },
+  })
 
   await client.createEvent({
     type: 'hitlAssigned',


### PR DESCRIPTION
We were getting/creating convo before checking if user exists. This might have created loose conversations