### PR TITLE
fix(integrations/livechat): fixed validation on livechat groups to allow for 0 as an ID

### DIFF
--- a/integrations/livechat-hitl/integration.definition.ts
+++ b/integrations/livechat-hitl/integration.definition.ts
@@ -5,7 +5,7 @@ import { events, configuration, states, channels, user } from './src/definitions
 export default new IntegrationDefinition({
   name: 'plus/livechat-hitl',
   title: 'LiveChat HITL',
-  version: '3.0.2',
+  version: '3.0.3',
   icon: 'icon.svg',
   description: 'This integration allows your bot to use LiveChat as a HITL provider. Messages will appear in LiveChat.',
   readme: 'hub.md',

--- a/integrations/livechat-hitl/src/actions/hitl.ts
+++ b/integrations/livechat-hitl/src/actions/hitl.ts
@@ -31,7 +31,7 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async ({ c
 
     const { email } = payload
 
-    if (!ctx.configuration.agentToken || ctx.configuration.groupId == null) {
+    if (!ctx.configuration.agentToken || ctx.configuration.groupId === null) {
       throw new RuntimeError('Agent token and group ID are required for HITL conversations')
     }
 

--- a/integrations/livechat-hitl/src/actions/hitl.ts
+++ b/integrations/livechat-hitl/src/actions/hitl.ts
@@ -31,7 +31,7 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async ({ c
 
     const { email } = payload
 
-    if (!ctx.configuration.agentToken || !ctx.configuration.groupId) {
+    if (!ctx.configuration.agentToken || ctx.configuration.groupId == null) {
       throw new RuntimeError('Agent token and group ID are required for HITL conversations')
     }
 


### PR DESCRIPTION
updated validation on manual config, it rejects a group ID of 0, but the default group in livechat has an ID of 0